### PR TITLE
Implementing SDKLogger Overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   * [GlobalConfig](#globalconfig)
     * [GlobalConfig.init](#globalconfiginit)
     * [Updating configuration](#updating-configuration)
+  * [SDKLogger](#sdklogger)
   * [ChatSession APIs](#chatsession-apis)
   * [ChatSession Events](#chatsession-events)
   * [Classes and Structs](#classes-and-structs)
@@ -136,6 +137,41 @@ If you have set the `GlobalConfig` object or want to update the configurations, 
 ```
 let globalConfig = GlobalConfig(region: .USEast1)
 chatSession.configure(config: globalConfig)
+```
+
+### SDKLogger
+The `SDKLogger` class is responsible for logging relevant runtime information to the console which is useful for debugging purposes. The `SDKLogger` will log key events such as establishing a connection or failures such as failing to send a message.
+
+#### `SDKLogger.configure`
+This API will allow you to override the SDK's built-in logger with your own [SDKLoggerProtocol](#sdkloggerprotocol) implementation. This is especially useful in cases where you would want to store logs for debugging purposes. Attaching these logs to issues filed in this project will greatly expedite the resolution process.
+
+```
+public static func configureLogger(_ logger: SDKLoggerProtocol) {
+    SDKLogger.logger = logger
+}
+```
+
+#### SDKLoggerProtocol
+The SDKLoggerProtocol is a protocol used for the `SDKLogger`.  Users can override the `SDKLogger` with any class that implements SDKLoggerProtocol.
+
+```
+public protocol SDKLoggerProtocol {
+    func logVerbose(
+        _ message: @autoclosure () -> String
+    )
+    func logInfo(
+        _ message: @autoclosure () -> String
+    )
+    func logDebug(
+        _ message: @autoclosure () -> String
+    )
+    func logFault(
+        _ message: @autoclosure () -> String
+    )
+    func logError(
+        _ message: @autoclosure () -> String
+    )
+}
 ```
 
 --------------------

--- a/Sources/Core/Service/ChatSession.swift
+++ b/Sources/Core/Service/ChatSession.swift
@@ -239,7 +239,6 @@ public class ChatSession: ChatSessionProtocol {
         guard let messageItem = transcriptItem as? Message,
               !messageItem.text.isEmpty,
               messageItem.messageDirection == .Incoming else {
-            SDKLogger.logger.logError("Could not send \(eventType.rawValue) receipt for \(String(describing: (transcriptItem as? Message)?.text))")
             return
         }
         

--- a/Sources/Core/Utils/Logger/SDKLogger.swift
+++ b/Sources/Core/Utils/Logger/SDKLogger.swift
@@ -5,35 +5,38 @@ import Foundation
 import OSLog
 
 
-class SDKLogger: SDKLoggerProtocol {
+public class SDKLogger: SDKLoggerProtocol {
     
-    static let logger = SDKLogger()
+    static var logger: SDKLoggerProtocol = SDKLogger()
     private let osLog: OSLog
     
     private init() {
         osLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "SDK.DefaultSubsystem", category: "SDKLogging")
     }
     
-    func logVerbose(_ message: @autoclosure () -> String) {
+    public func logVerbose(_ message: @autoclosure () -> String) {
         os_log("%{public}@", log: osLog, type: .default, message())
     }
     
-    func logInfo(_ message: @autoclosure () -> String) {
+    public func logInfo(_ message: @autoclosure () -> String) {
         os_log("%{public}@", log: osLog, type: .info, message())
     }
     
-    func logDebug(_ message: @autoclosure () -> String) {
+    public func logDebug(_ message: @autoclosure () -> String) {
         os_log("%{public}@", log: osLog, type: .debug, message())
     }
     
-    func logFault(_ message: @autoclosure () -> String) {
+    public func logFault(_ message: @autoclosure () -> String) {
         os_log("%{public}@", log: osLog, type: .fault, message())
     }
     
-    func logError(_ message: @autoclosure () -> String) {
+    public func logError(_ message: @autoclosure () -> String) {
         os_log("%{public}@", log: osLog, type: .error, message())
     }
     
+    public static func configure(_ logger: SDKLoggerProtocol) {
+        SDKLogger.logger = logger
+    }
 }
 
 

--- a/Sources/Core/Utils/Logger/SDKLogger.swift
+++ b/Sources/Core/Utils/Logger/SDKLogger.swift
@@ -34,7 +34,7 @@ public class SDKLogger: SDKLoggerProtocol {
         os_log("%{public}@", log: osLog, type: .error, message())
     }
     
-    public static func configure(_ logger: SDKLoggerProtocol) {
+    public static func configureLogger(_ logger: SDKLoggerProtocol) {
         SDKLogger.logger = logger
     }
 }

--- a/Sources/Core/Utils/Logger/SDKLoggerProtocol.swift
+++ b/Sources/Core/Utils/Logger/SDKLoggerProtocol.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-protocol SDKLoggerProtocol {
+public protocol SDKLoggerProtocol {
     func logVerbose(
         _ message: @autoclosure () -> String
     )


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR implements SDKLogger overrides so that users can implement custom logging logic for SDK logs.

### Testing:
- Tested via iOS UI Example

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

