### PR TITLE
Fix leak in ChatService.disconnectChatSession.

### DIFF
--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -239,6 +239,7 @@ class ChatService : ChatServiceProtocol {
         if (!connectionDetailsProvider.isChatSessionActive()) {
             self.websocketManager?.disconnect()
             self.clearSubscriptionsAndPublishers()
+            completion(true, nil)
             return
         }
         guard let connectionDetails = connectionDetailsProvider.getConnectionDetails() else {


### PR DESCRIPTION
**Issue Number: - **

### Description:

ChatService.disconnectChatSession is leaking resources because it is not calling completion block on all its paths. Because of that its clients will hang forever waiting for completion block to be called. This will further lead to leaked tasks (or continuations if SDK users wrap callback APIs into async-await continuations) in the application that uses amazon-connect-chat-ios SDK.

This fix ads call to completion block at the place where it was missing. Assumption is that if chat session is not active, and we call disconnect, we should consider this as successful disconnection.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* NO

*Does this change introduce any new dependency?* NO

---

### Testing:
*Is the code unit tested?*
No.

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

No, we detected the leaks/crashes in our application and tracked the root cause. The bug is obvious by just looking at the ChatService.disconnectChatSession code, so there is no point in trying to test it on sample UI.
