### PR TITLE
Updated privacy manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Then run `pod install` in your project's root directory
 3. Unzip the downloaded file, if necessary.
 4. Drag and drop the `AmazonConnectChatIOS.xcframework` into your Xcode project.
 
+>⚠️ Important: Please remember to add 'AWSCore' and 'AWSConnectParticipant' from [AWS IOS SDK](https://github.com/aws-amplify/aws-sdk-ios) while using binaries.
+
+
 #### How to Import the XCFramework
 
 Once you have added the `AmazonConnectChatIOS.xcframework` to your project, you need to import it into your code. Here are the steps:

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,19 +1,27 @@
-{
-  "data": [
-    {
-      "type": "attachments",
-      "purpose": [
-        "app_functionality"
-      ],
-      "optional": true,
-      "linked": false
-    }
-  ],
-  "thirdPartyDataSharing": {
-    "sharedData": [],
-    "thirdPartyIdentifiers": []
-  },
-  "dataDeclarationVersions": {
-    "version": "1.0"
-  }
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict>
+            <key>type</key>
+            <string>attachments</string>
+            <key>purpose</key>
+            <array>
+                <string>app_functionality</string>
+            </array>
+            <key>optional</key>
+            <true/>
+            <key>linked</key>
+            <false/>
+        </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+</dict>
+</plist>


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

- Updating privacy manifest file to correct format. No impact on code.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

