### PR TITLE
Previous session transcript fix , made initializer public

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -29,63 +29,23 @@ jobs:
     - name: Install xcpretty
       run: gem install xcpretty
 
-    - name: Clear Swift Package Cache
-      run: rm -rf ~/Library/Caches/org.swift.swiftpm
-
-
-    - name: Resolve Dependencies
-      run: |
-        echo "::group::Resolving Dependencies"
-        swift package resolve
-        echo "::endgroup::"
-
-    - name: Clean Derived Data
-      run: |
-        echo "::group::Cleaning Derived Data"
-        rm -rf ~/Library/Developer/Xcode/DerivedData
-        echo "::endgroup::"
-
-    - name: Build Dependencies
-      run: |
-        xcodebuild -resolvePackageDependencies \
-        -scheme AmazonConnectChatIOS \
-        -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-
-    # - name: Build Framework
+    # - name: Clean and Build SDK
     #   run: |
-    #     xcodebuild clean build \
-    #     -scheme AmazonConnectChatIOS \
-    #     -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-    #     -derivedDataPath ./DerivedData
-
-    # - name: Run Tests
-    #   run: |
-    #     xcodebuild test \
-    #     -scheme AmazonConnectChatIOS \
-    #     -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-    #     -derivedDataPath ./DerivedData
-        
-    - name: Clean and Build SDK
-      run: |
-        echo "::group::Cleaning and Building SDK"
-        set -e
-        xcodebuild clean -project AmazonConnectChatIOS.xcodeproj \
-                         -scheme AmazonConnectChatIOS \
-                         -sdk iphonesimulator \
-                         -configuration Debug \
-                         build 2>&1 | tee xcodebuild.log | xcpretty --color --simple
-        exit ${PIPESTATUS[0]}
-        echo "::endgroup::"
-
+    #     echo "::group::Clean and Build SDK"
+    #     xcodebuild clean -project AmazonConnectChatIOS.xcodeproj \
+    #                      -scheme AmazonConnectChatIOS \
+    #                      -sdk iphonesimulator \
+    #                      -configuration Debug \
+    #                      build
+    #     echo "::endgroup::"
     - name: Run Unit Tests
       run: |
-        echo "::group::Running Unit Tests"
-        set -e
+        echo "::group::Run Unit Tests"
         xcodebuild test -scheme AmazonConnectChatIOS \
                         -sdk iphonesimulator \
-                        -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+                        -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' \
                         -configuration Debug \
                         -enableCodeCoverage YES \
-                        2>&1 | tee xcodebuild.log | xcpretty --color --simple
-        exit ${PIPESTATUS[0]}
+                        -testPlan AmazonConnectChatIOS.xctestplan \
+                        2>&1 | xcpretty --color --simple
         echo "::endgroup::"

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -28,18 +28,42 @@ jobs:
 
     - name: Install xcpretty
       run: gem install xcpretty
-      
+
+    - name: Clear Swift Package Cache
+      run: rm -rf ~/Library/Caches/org.swift.swiftpm
+
+
+    - name: Resolve Dependencies
+      run: |
+        echo "::group::Resolving Dependencies"
+        swift package resolve
+        echo "::endgroup::"
+
     - name: Clean Derived Data
       run: |
         echo "::group::Cleaning Derived Data"
         rm -rf ~/Library/Developer/Xcode/DerivedData
         echo "::endgroup::"
 
-    - name: Resolve Dependencies
+    - name: Build Dependencies
       run: |
-        echo "::group::Resolving Dependencies"
-        xcodebuild -resolvePackageDependencies
-        echo "::endgroup::"
+        xcodebuild -resolvePackageDependencies \
+        -scheme AmazonConnectChatIOS \
+        -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
+
+    # - name: Build Framework
+    #   run: |
+    #     xcodebuild clean build \
+    #     -scheme AmazonConnectChatIOS \
+    #     -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
+    #     -derivedDataPath ./DerivedData
+
+    # - name: Run Tests
+    #   run: |
+    #     xcodebuild test \
+    #     -scheme AmazonConnectChatIOS \
+    #     -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
+    #     -derivedDataPath ./DerivedData
         
     - name: Clean and Build SDK
       run: |
@@ -57,10 +81,9 @@ jobs:
       run: |
         echo "::group::Running Unit Tests"
         set -e
-        xcodebuild test -project AmazonConnectChatIOS.xcodeproj \
-                        -scheme AmazonConnectChatIOS \
+        xcodebuild test -scheme AmazonConnectChatIOS \
                         -sdk iphonesimulator \
-                        -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' \
+                        -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
                         -configuration Debug \
                         -enableCodeCoverage YES \
                         2>&1 | tee xcodebuild.log | xcpretty --color --simple

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -28,24 +28,41 @@ jobs:
 
     - name: Install xcpretty
       run: gem install xcpretty
+      
+    - name: Clean Derived Data
+      run: |
+        echo "::group::Cleaning Derived Data"
+        rm -rf ~/Library/Developer/Xcode/DerivedData
+        echo "::endgroup::"
 
+    - name: Resolve Dependencies
+      run: |
+        echo "::group::Resolving Dependencies"
+        xcodebuild -resolvePackageDependencies
+        echo "::endgroup::"
+        
     - name: Clean and Build SDK
       run: |
-        echo "::group::Clean and Build SDK"
+        echo "::group::Cleaning and Building SDK"
+        set -e
         xcodebuild clean -project AmazonConnectChatIOS.xcodeproj \
                          -scheme AmazonConnectChatIOS \
                          -sdk iphonesimulator \
                          -configuration Debug \
-                         build
+                         build 2>&1 | tee xcodebuild.log | xcpretty --color --simple
+        exit ${PIPESTATUS[0]}
         echo "::endgroup::"
+
     - name: Run Unit Tests
       run: |
-        echo "::group::Run Unit Tests"
+        echo "::group::Running Unit Tests"
+        set -e
         xcodebuild test -project AmazonConnectChatIOS.xcodeproj \
                         -scheme AmazonConnectChatIOS \
                         -sdk iphonesimulator \
                         -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' \
                         -configuration Debug \
                         -enableCodeCoverage YES \
-                        2>&1 | xcpretty --color --simple
+                        2>&1 | tee xcodebuild.log | xcpretty --color --simple
+        exit ${PIPESTATUS[0]}
         echo "::endgroup::"

--- a/AmazonConnectChatIOS.xcodeproj/project.pbxproj
+++ b/AmazonConnectChatIOS.xcodeproj/project.pbxproj
@@ -38,8 +38,8 @@
 		7E58A6232BBDDBF900965327 /* ChatSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E58A6222BBDDBF900965327 /* ChatSession.swift */; };
 		7E58A6272BBDDE4A00965327 /* AWSClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E58A6262BBDDE4A00965327 /* AWSClient.swift */; };
 		7E58A6292BBE415700965327 /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E58A6282BBE415700965327 /* ChatService.swift */; };
-		7E78DCFD2C3C93DB00D5351A /* AWSConnectParticipant in Frameworks */ = {isa = PBXBuildFile; productRef = 7E78DCFC2C3C93DB00D5351A /* AWSConnectParticipant */; settings = {ATTRIBUTES = (Required, ); }; };
-		7E78DCFF2C3C93DB00D5351A /* AWSCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7E78DCFE2C3C93DB00D5351A /* AWSCore */; };
+		7E5D95ED2D399850005E20AC /* AWSConnectParticipant in Frameworks */ = {isa = PBXBuildFile; productRef = 7E5D95EC2D399850005E20AC /* AWSConnectParticipant */; };
+		7E5D95EF2D399850005E20AC /* AWSCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7E5D95EE2D399850005E20AC /* AWSCore */; };
 		7E91597B2BC0A92E00821C05 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E91597A2BC0A92E00821C05 /* Constants.swift */; };
 		7EAED4CB2CEDD4340091F65E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 7EAED4CA2CEDD4340091F65E /* PrivacyInfo.xcprivacy */; };
 		7EC0A21B2BC79D7B00DB47F4 /* WebSocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC0A21A2BC79D7A00DB47F4 /* WebSocketManager.swift */; };
@@ -139,8 +139,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7E78DCFD2C3C93DB00D5351A /* AWSConnectParticipant in Frameworks */,
-				7E78DCFF2C3C93DB00D5351A /* AWSCore in Frameworks */,
+				7E5D95ED2D399850005E20AC /* AWSConnectParticipant in Frameworks */,
+				7E5D95EF2D399850005E20AC /* AWSCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -381,8 +381,8 @@
 			);
 			name = AmazonConnectChatIOS;
 			packageProductDependencies = (
-				7E78DCFC2C3C93DB00D5351A /* AWSConnectParticipant */,
-				7E78DCFE2C3C93DB00D5351A /* AWSCore */,
+				7E5D95EC2D399850005E20AC /* AWSConnectParticipant */,
+				7E5D95EE2D399850005E20AC /* AWSCore */,
 			);
 			productName = AmazonConnectChatIOS;
 			productReference = 7E58A5D42BB5F3DA00965327 /* AmazonConnectChatIOS.framework */;
@@ -434,7 +434,7 @@
 			);
 			mainGroup = 7E58A5CA2BB5F3DA00965327;
 			packageReferences = (
-				7E78DCFB2C3C93DB00D5351A /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */,
+				7E5D95EB2D399850005E20AC /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */,
 			);
 			productRefGroup = 7E58A5D52BB5F3DA00965327 /* Products */;
 			projectDirPath = "";
@@ -806,25 +806,25 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		7E78DCFB2C3C93DB00D5351A /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */ = {
+		7E5D95EB2D399850005E20AC /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/aws-amplify/aws-sdk-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.36.3;
+				minimumVersion = 2.40.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7E78DCFC2C3C93DB00D5351A /* AWSConnectParticipant */ = {
+		7E5D95EC2D399850005E20AC /* AWSConnectParticipant */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7E78DCFB2C3C93DB00D5351A /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */;
+			package = 7E5D95EB2D399850005E20AC /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */;
 			productName = AWSConnectParticipant;
 		};
-		7E78DCFE2C3C93DB00D5351A /* AWSCore */ = {
+		7E5D95EE2D399850005E20AC /* AWSCore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7E78DCFB2C3C93DB00D5351A /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */;
+			package = 7E5D95EB2D399850005E20AC /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */;
 			productName = AWSCore;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/AmazonConnectChatIOS.xcodeproj/project.pbxproj
+++ b/AmazonConnectChatIOS.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		7E58A6232BBDDBF900965327 /* ChatSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E58A6222BBDDBF900965327 /* ChatSession.swift */; };
 		7E58A6272BBDDE4A00965327 /* AWSClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E58A6262BBDDE4A00965327 /* AWSClient.swift */; };
 		7E58A6292BBE415700965327 /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E58A6282BBE415700965327 /* ChatService.swift */; };
-		7E78DCFD2C3C93DB00D5351A /* AWSConnectParticipant in Frameworks */ = {isa = PBXBuildFile; productRef = 7E78DCFC2C3C93DB00D5351A /* AWSConnectParticipant */; };
+		7E78DCFD2C3C93DB00D5351A /* AWSConnectParticipant in Frameworks */ = {isa = PBXBuildFile; productRef = 7E78DCFC2C3C93DB00D5351A /* AWSConnectParticipant */; settings = {ATTRIBUTES = (Required, ); }; };
 		7E78DCFF2C3C93DB00D5351A /* AWSCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7E78DCFE2C3C93DB00D5351A /* AWSCore */; };
 		7E91597B2BC0A92E00821C05 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E91597A2BC0A92E00821C05 /* Constants.swift */; };
 		7EAED4CB2CEDD4340091F65E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 7EAED4CA2CEDD4340091F65E /* PrivacyInfo.xcprivacy */; };

--- a/AmazonConnectChatIOSTests/Core/Network/Mocks/MockWebSocketManager.swift
+++ b/AmazonConnectChatIOSTests/Core/Network/Mocks/MockWebSocketManager.swift
@@ -15,7 +15,7 @@ class MockWebsocketManager: WebsocketManagerProtocol {
         SDKLogger.logger.logDebug("MockWebsocketManager: Connected to \(String(describing: wsUrl))")
     }
     
-    func disconnect() {
+    func disconnect(reason: String?) {
         // Simulate disconnection logic if needed
         SDKLogger.logger.logDebug("MockWebsocketManager: Disconnected")
     }

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/aws-amplify/aws-sdk-ios-spm", from: "2.36.4")
+        .package(url: "https://github.com/aws-amplify/aws-sdk-ios-spm", from: "2.40.0")
     ],
     targets: [
         .target(

--- a/Sources/Core/Models/Event.swift
+++ b/Sources/Core/Models/Event.swift
@@ -16,7 +16,7 @@ public class Event: TranscriptItem, EventProtocol {
     public var displayName: String?
     public var eventDirection: MessageDirection?
     
-    init(text: String? = nil, timeStamp: String, contentType: String, messageId: String, displayName: String? = nil, participant: String? = nil, eventDirection: MessageDirection? = .Common, serializedContent: [String: Any]) {
+    public init(text: String? = nil, timeStamp: String, contentType: String, messageId: String, displayName: String? = nil, participant: String? = nil, eventDirection: MessageDirection? = .Common, serializedContent: [String: Any]) {
         self.participant = participant
         self.text = text
         self.displayName = displayName

--- a/Sources/Core/Models/Message.swift
+++ b/Sources/Core/Models/Message.swift
@@ -26,7 +26,7 @@ public class Message: TranscriptItem, MessageProtocol {
     public var displayName: String?
     @Published public var metadata: (any MetadataProtocol)?
 
-    init(participant: String, text: String, contentType: String, messageDirection: MessageDirection? = nil, timeStamp: String, attachmentId: String? = nil, messageId: String? = nil,
+    public init(participant: String, text: String, contentType: String, messageDirection: MessageDirection? = nil, timeStamp: String, attachmentId: String? = nil, messageId: String? = nil,
                 displayName: String? = nil, serializedContent: [String: Any], metadata: (any MetadataProtocol)? = nil) {
         self.participant = participant
         self.text = text

--- a/Sources/Core/Models/Metadata.swift
+++ b/Sources/Core/Models/Metadata.swift
@@ -21,7 +21,7 @@ public class Metadata: TranscriptItem, MetadataProtocol {
     @Published public var status: MessageStatus?
     @Published public var eventDirection: MessageDirection?
     
-    init(status: MessageStatus? = nil, messageId: String? = nil, timeStamp: String, contentType: String, eventDirection: MessageDirection? = .Common, serializedContent: [String: Any]) {
+    public init(status: MessageStatus? = nil, messageId: String? = nil, timeStamp: String, contentType: String, eventDirection: MessageDirection? = .Common, serializedContent: [String: Any]) {
         self.status = status
         self.eventDirection = eventDirection
         super.init(timeStamp: timeStamp, contentType: contentType, id: messageId, serializedContent: serializedContent)

--- a/Sources/Core/Models/WebSocketErrorCodes.swift
+++ b/Sources/Core/Models/WebSocketErrorCodes.swift
@@ -5,4 +5,5 @@ public enum WebSocketErrorCodes: Int {
     case NETWORK_DISCONNECTED = -1005
     case BAD_SERVER_RESPONSE = -1011
     case SOFTWARE_ABORT = 53
+    case OPERATION_TIMED_OUT = 60
 }

--- a/Sources/Core/Service/ChatSession.swift
+++ b/Sources/Core/Service/ChatSession.swift
@@ -111,17 +111,13 @@ public class ChatSession: ChatSessionProtocol {
             DispatchQueue.main.async {
                 switch event {
                 case .connectionEstablished:
-                    ConnectionDetailsProvider.shared.setChatSessionState(isActive: true)
                     self?.onConnectionEstablished?()
                 case .connectionBroken:
                     self?.onConnectionBroken?()
                 case .connectionReEstablished:
                     self?.onConnectionReEstablished?()
                 case .chatEnded:
-                    if (self != nil && ConnectionDetailsProvider.shared.isChatSessionActive() == true) {
-                        ConnectionDetailsProvider.shared.setChatSessionState(isActive: false)
-                        self?.onChatEnded?()
-                    }
+                    self?.onChatEnded?()
                 default:
                     break
                 }
@@ -195,6 +191,7 @@ public class ChatSession: ChatSessionProtocol {
                 if success {
                     self.onChatEnded?()
                     self.cleanupSubscriptions()
+                    ConnectionDetailsProvider.shared.setChatSessionState(isActive: false)
                     completion(.success(()))
                 } else if let error = error {
                     SDKLogger.logger.logError("Error disconnecting chat session: \(error.localizedDescription)")

--- a/Sources/Core/Utils/HttpClient/HttpHeader.swift
+++ b/Sources/Core/Utils/HttpClient/HttpHeader.swift
@@ -20,6 +20,7 @@ extension HttpHeader {
         case contentLength = "Content-Length"
         case contentDisposition = "Content-Disposition"
         case amzMetaAccountId = "x-amz-meta-account_id"
+        case amzExpctedBucketOwner = "x-amz-expected-bucket-owner"
     }
 }
 


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

- The issue arises when users attempt to load the transcript from a previous session using persistent chat. While we were processing the response, we had added a “closing” WebSocket and sent a “chat has ended” callback to the customer after parsing an “chat ended” event that we received in the transcript. This fix prevents the action from being taken at the parsing level and instead sends the “chat has ended” callback to the customer once they disconnect and close the WebSocket simultaneously.
- Made Message/Event/Metadata initializers public #45 
- Included Chat disconnect event leak #42 
- Added `operation time out` to websocket connection retry. 


---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

