### PR TITLE
[WebSocket]: Exposing suspend/resume methods + background/foreground logic

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload Semgrep results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: semgrep-results
           path: semgrep.sarif

--- a/README.md
+++ b/README.md
@@ -230,6 +230,23 @@ func disconnect(completion: @escaping (Result<Void, Error>) -> Void)
 
 --------------------
 
+#### `ChatSession.suspendWebSocketConnection`
+Disconnects the websocket and suspends reconnection attempts.
+
+```
+func suspendWebSocketConnection()
+```
+
+--------------------
+
+#### `ChatSession.resumeWebSocketConnection`
+Resumes a suspended websocket and attempts to reconnect.
+```
+func resumeWebSocketConnection()
+```
+
+--------------------
+
 #### `ChatSession.sendMessage`
 Sends a message within the chat session.
 

--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -9,6 +9,8 @@ import UniformTypeIdentifiers
 protocol ChatServiceProtocol {
     func createChatSession(chatDetails: ChatDetails, completion: @escaping (Bool, Error?) -> Void)
     func disconnectChatSession(completion: @escaping (Bool, Error?) -> Void)
+    func suspendWebSocketConnection()
+    func resumeWebSocketConnection()
     func sendMessage(contentType: ContentType, message: String, completion: @escaping (Bool, Error?) -> Void)
     func sendEvent(event: ContentType, content: String?, completion: @escaping (Bool, Error?) -> Void)
     func sendMessageReceipt(event: MessageReceiptType, messageId: String, completion: @escaping (Result<Void, Error>) -> Void)
@@ -264,6 +266,16 @@ class ChatService : ChatServiceProtocol {
                 completion(false, error)
             }
         }
+    }
+    
+    func suspendWebSocketConnection() {
+        SDKLogger.logger.logDebug("Suspending WebSocket connections")
+        self.websocketManager?.suspendWebSocketConnection()
+    }
+    
+    func resumeWebSocketConnection() {
+        SDKLogger.logger.logDebug("Resuming WebSocket connections")
+        self.websocketManager?.resumeWebSocketConnection()
     }
     
     func sendMessage(contentType: ContentType, message: String, completion: @escaping (Bool, Error?) -> Void) {

--- a/Sources/Core/Service/ChatSession.swift
+++ b/Sources/Core/Service/ChatSession.swift
@@ -21,6 +21,14 @@ public protocol ChatSessionProtocol {
     /// - Parameter completion: The completion handler to call when the disconnect operation is complete.
     func disconnect(completion: @escaping (Result<Void, Error>) -> Void)
     
+    /// Disconnects the websocket and suspends reconnection attempts.
+    /// - Parameter completion: The completion handler to call when the suspend operation is complete.
+    func suspendWebSocketConnection()
+    
+    /// Resumes a suspended websocket and attempts to reconnect.
+    /// - Parameter completion: The completion handler to call when the resume operation is complete.
+    func resumeWebSocketConnection()
+    
     /// Sends a message within the chat session.
     /// - Parameters:
     ///   - contentType: The type of the message content.
@@ -199,6 +207,14 @@ public class ChatSession: ChatSessionProtocol {
                 }
             }
         }
+    }
+    
+    public func suspendWebSocketConnection() {
+        chatService.suspendWebSocketConnection()
+    }
+    
+    public func resumeWebSocketConnection() {
+        chatService.resumeWebSocketConnection()
     }
     
     /// Sends a message within the chat session.


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

There are two WebSocket related changes in this PR

#### Suspend and Resume function 

This PR implements and exposes two new functions, `suspendWebSocketConnection` and `resumeWebSocketConnection`.  Suspending websocket connections will disconnect the websocket and prevent any further attempts to re-establish a websocket connection.  The suspension can only be lifted by calling `resumeWebSocketConnection` which will immediately re-attempt to re-establish a connection to the active chat session.

#### Background/Foreground scenarios

This PR also implements background/foreground scenarios for websocket connectivity.  When backgrounded, the SDK will now preemptively disconnect the websocket and attempt to re-establish the connection when foregrounded.  This is a preventative measure since the OS will kill any app that attempts to maintain a websocket connection while backgrounded.


---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

Unit testing will come as fast-follow

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

Yes

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

