### PR TITLE
Exposing methods tofetch ConnectionDetailsProvider and retry undelive…

### DIFF
--- a/AmazonConnectChatIOSTests/Core/Service/MockChatService.swift
+++ b/AmazonConnectChatIOSTests/Core/Service/MockChatService.swift
@@ -10,6 +10,7 @@ class MockChatService: ChatService {
     var mockCreateChatSession = true
     var mockDisconnectChatSession = true
     var mockSendMessage = true
+    var mockResendFailedMessage = true
     var mockSendEvent = true
     var mockSendMessageReceipt = true
     var mockSendPendingMessageReceipts = true
@@ -24,6 +25,7 @@ class MockChatService: ChatService {
     var numCreateChatSessionCalled = 0
     var numDisconnectChatSessionCalled = 0
     var numSendMessageCalled = 0
+    var numResendFailedMessageCalled = 0
     var numSendEventCalled = 0
     var numSendMessageReceiptCalled = 0
     var numSendPendingMessageReceiptsCalled = 0
@@ -38,6 +40,7 @@ class MockChatService: ChatService {
     var createChatSessionResult: Result<Void, Error>?
     var disconnectChatSessionResult: Result<Void, Error>?
     var sendMessageResult: Result<Void, Error>?
+    var resendFailedMessageResult: Result<Void, Error>?
     var sendEventResult: (Bool, Error?)?
     var sendMessageReceiptResult: Result<Void, Error>?
     var sendPendingMessageReceiptsResult: Result<AmazonConnectChatIOS.MessageReceiptType, Error>?
@@ -103,6 +106,26 @@ class MockChatService: ChatService {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             if let result = self.sendMessageResult {
+                switch result {
+                case .success:
+                    completion(true, nil)
+                case .failure(let error):
+                    completion(false, error)
+                }
+            }
+        }
+    }
+    
+    override func resendFailedMessage(messageId: String, completion: @escaping (Bool, Error?) -> Void) {
+        
+        numSendMessageCalled += 1
+        if !mockSendMessage {
+            super.resendFailedMessage(messageId: messageId, completion: completion)
+            return
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            if let result = self.resendFailedMessageResult {
                 switch result {
                 case .success:
                     completion(true, nil)

--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ func configure(config: GlobalConfig)
 
 --------------------
 
+#### `ChatSession.getConnectionDetailsProvider`
+Returns a `ConnectionDetailsProvider` object that includes connection details.
+
+```
+fun getConnectionDetailsProvider(): ConnectionDetailsProvider
+```
+* Return type: [ConnectionDetailsProvider](#connectiondetailsprovider)
+
+--------------------
+
 #### `ChatSession.connect`
 Attempts to connect to a chat session with the given details.
 
@@ -390,6 +400,20 @@ func getAttachmentDownloadUrl(attachmentId: String, completion: @escaping (Resul
 
 --------------------
 
+
+#### `ChatSession.resendFailedMessage`
+Retry a text message or attachment that failed to be sent.
+
+```
+func resendFailedMessage(messageId: String, completion: @escaping (Result<Void, Error>) -> Void)
+```
+
+* `messageId`
+  * messageId The Id of the message that failed to be sent.
+  * Type: `String`
+  
+--------------------
+
 #### `ChatSession.isChatSessionActive`
 Returns a boolean indicating whether the chat session is still active.
 
@@ -530,6 +554,63 @@ public struct ChatDetails {
 * `participantToken`
   * Participant token received via [StartChatContact](https://docs.aws.amazon.com/connect/latest/APIReference/API_StartChatContact.html) response
   * Type: `String`
+  
+---------------------
+### ConnectionDetailsProvider
+
+```
+public protocol ConnectionDetailsProviderProtocol {
+    func updateChatDetails(newDetails: ChatDetails)
+    func getConnectionDetails() -> ConnectionDetails?
+    func updateConnectionDetails(newDetails: ConnectionDetails)
+    func getChatDetails() -> ChatDetails?
+    func isChatSessionActive() -> Bool
+    func setChatSessionState(isActive: Bool) -> Void
+}
+```
+* `updateChatDetails`
+  * Updates chat details
+  * newDetails
+    * Type: `ChatDetails`
+* `getConnectionDetails`
+  * Gets connection details received via [CreateParticipantConnection](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_CreateParticipantConnection.html) response
+  * Return type: [ConnectionDetails](#connectiondetails)
+* `updateConnectionDetails`
+  * Updates connection details 
+  * newDetails
+    * Type: [ConnectionDetails](#connectiondetails)
+* `getChatDetails`
+  * Gets chat details
+  * Return type: `ChatDetails`
+* `isChatSessionActive`
+  * Gets chat session active state
+  * Return type: Boolean
+* `setChatSessionState`
+  * Sets chat session state
+  * isActive
+    * Type: Boolean
+
+---------------------
+
+### ConnectionDetails
+
+```
+public struct ConnectionDetails {
+    public func getWebsocketUrl() -> String?
+    public func getConnectionToken() -> String?
+    public func getExpiry() -> Date?
+}
+```
+* `getWebsocketUrl`
+  * Returns URL of the websocket received via [CreateParticipantConnection](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_CreateParticipantConnection.html) response
+  * Return type: `String`
+* `getConnectionToken`
+  * Returns connection token received via [CreateParticipantConnection](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_CreateParticipantConnection.html) response
+  * Return type: `String`
+* `getExpiry`
+  * Returns expiration of the token received via [CreateParticipantConnection](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_CreateParticipantConnection.html) response
+  * Return type: `Date`
+
 ---------------------
 ### ContentType
 

--- a/Sources/Core/Models/ConnectionDetails.swift
+++ b/Sources/Core/Models/ConnectionDetails.swift
@@ -7,4 +7,16 @@ public struct ConnectionDetails {
     let websocketUrl: String?
     let connectionToken: String?
     let expiry: Date?
+    
+    public func getWebsocketUrl() -> String? {
+        return websocketUrl
+    }
+    
+    public func getConnectionToken() -> String? {
+        return connectionToken
+    }
+    
+    public func getExpiry() -> Date? {
+        return expiry
+    }
 }

--- a/Sources/Core/Utils/ConnectionDetailsProvider.swift
+++ b/Sources/Core/Utils/ConnectionDetailsProvider.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-protocol ConnectionDetailsProviderProtocol {
+public protocol ConnectionDetailsProviderProtocol {
     func updateChatDetails(newDetails: ChatDetails)
     func getConnectionDetails() -> ConnectionDetails?
     func updateConnectionDetails(newDetails: ConnectionDetails)


### PR DESCRIPTION
…red messages

**Issue Number:** 
#[48](https://github.com/amazon-connect/amazon-connect-chat-ios/issues/48)

### Description:
*What are the changes? Why are we making them?*
1. Exposed method to retry undelivered text messages and attachments.
2. Updated filtering logic in `sendMessageReceipt ` to check the `participantRole` instead of  `messageDirection` to make the check consistent in Android and iOS SDKs.
3. Exposed method to get connection details provider which supports getting connection details including connection token. This token enables consumers to call [Connect Participant APIs](https://docs.aws.amazon.com/connect/latest/APIReference/API_Operations_Amazon_Connect_Participant_Service.html) directly in their apps.
4. Updated README with instructions to call above methods

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [NO]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?* 
Unit tests will come as fast follow.

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*
Yes

*List manual testing steps:*
 - Add Steps below: 
1. Manually started a 2way chat between customer and agent, sent a few messages, turned internet off on customer device, attempted to send a attachment and a text message and saw failures, hit the retry button and verified the text message and attachment were sent successfully and seen on agent CCP, with the old placeholders removed.
2. Manually tested calling chatSession.getConnectionDetailsProvider().getConnectionDetails().getConnectionToken() and verified the connection token was received. Also verified a new connection token is received after background/foreground events.

![IMG_3534](https://github.com/user-attachments/assets/8352b94f-4d07-4856-8d7f-9177c2e5ef1a)
![IMG_3535](https://github.com/user-attachments/assets/9b776c24-9733-45c6-82d1-61eae06db37b)

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

