### PR TITLE
Implementing ChatSession.reset API

### DIFF
--- a/AmazonConnectChatIOSTests/Core/Network/Mocks/MockWebSocketManager.swift
+++ b/AmazonConnectChatIOSTests/Core/Network/Mocks/MockWebSocketManager.swift
@@ -7,17 +7,39 @@ import AWSConnectParticipant
 @testable import AmazonConnectChatIOS
 
 class MockWebsocketManager: WebsocketManagerProtocol {
+    var mockConnectionStatus = false
+    var wsUrl: URL = URL(string: "about:blank")!
+    
+    init(wsUrl: URL = URL(string: "about:blank")!) {
+        self.wsUrl = wsUrl
+        self.connect(wsUrl: self.wsUrl)
+    }
+    
+    func suspendWebSocketConnection() {
+        // Simulate suspension logic if needed
+        SDKLogger.logger.logDebug("MockWebsocketManager: Suspended WebSocket Connection")
+        self.mockConnectionStatus = false
+    }
+    
+    func resumeWebSocketConnection() {
+        // Simulate resume logic if needed
+        SDKLogger.logger.logDebug("MockWebsocketManager: Resume WebSocket Connection")
+        self.mockConnectionStatus = true
+    }
+    
     var eventPublisher = PassthroughSubject<ChatEvent, Never>()
     var transcriptPublisher = PassthroughSubject<TranscriptItem, Never>()
     
     func connect(wsUrl: URL?,isReconnect: Bool? = false) {
         // Simulate connection logic if needed
         SDKLogger.logger.logDebug("MockWebsocketManager: Connected to \(String(describing: wsUrl))")
+        self.mockConnectionStatus = true
     }
     
     func disconnect(reason: String?) {
         // Simulate disconnection logic if needed
         SDKLogger.logger.logDebug("MockWebsocketManager: Disconnected")
+        self.mockConnectionStatus = false
     }
     
     func formatAndProcessTranscriptItems(_ items: [AWSConnectParticipantItem]) -> [TranscriptItem] {

--- a/AmazonConnectChatIOSTests/Core/Service/MockChatService.swift
+++ b/AmazonConnectChatIOSTests/Core/Service/MockChatService.swift
@@ -52,8 +52,6 @@ class MockChatService: ChatService {
     var completeAttachmentUploadResult: (Bool, Error?)?
     var getTranscriptResult: Result<TranscriptResponse, Error>?
 
-    var websocketManager: WebsocketManagerProtocol?
-
     override func createChatSession(chatDetails: ChatDetails, completion: @escaping (Bool, Error?) -> Void) {
         
         numCreateChatSessionCalled += 1

--- a/AmazonConnectChatIOSTests/Core/utils/MockConnectionDetailsProvider.swift
+++ b/AmazonConnectChatIOSTests/Core/utils/MockConnectionDetailsProvider.swift
@@ -33,4 +33,10 @@ class MockConnectionDetailsProvider: ConnectionDetailsProviderProtocol {
     func setChatSessionState(isActive: Bool) {
         isChatActive = isActive
     }
+    
+    func reset() {
+        mockConnectionDetails = nil
+        mockChatDetails = nil
+        isChatActive = true
+    }
 }

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ func disconnect(completion: @escaping (Result<Void, Error>) -> Void)
 --------------------
 
 #### `ChatSession.reset`
-Resets the ChatSession object which will disconnect the webSocket and remove all session related data.
+Resets the ChatSession object which will disconnect the webSocket and remove all session related data without disconnected the participant from the chat contact.
 
 ```
 func reset()

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ func disconnect(completion: @escaping (Result<Void, Error>) -> Void)
 --------------------
 
 #### `ChatSession.reset`
-Resets the ChatSession object which will disconnect the webSocket and remove all session related data without disconnected the participant from the chat contact.
+Resets the ChatSession object which will disconnect the webSocket and remove all session related data without disconnecting the participant from the chat contact.
 
 ```
 func reset()

--- a/README.md
+++ b/README.md
@@ -240,6 +240,15 @@ func disconnect(completion: @escaping (Result<Void, Error>) -> Void)
 
 --------------------
 
+#### `ChatSession.reset`
+Resets the ChatSession object which will disconnect the webSocket and remove all session related data.
+
+```
+func reset()
+```
+
+--------------------
+
 #### `ChatSession.suspendWebSocketConnection`
 Disconnects the websocket and suspends reconnection attempts.
 

--- a/Sources/Core/Network/AWSClient.swift
+++ b/Sources/Core/Network/AWSClient.swift
@@ -114,6 +114,7 @@ class AWSClient: AWSClientProtocol {
         self.region = AWSRegionType(rawValue: config.region.rawValue) ?? Constants.DEFAULT_REGION
         
         let participantService = AWSServiceConfiguration(region: self.region, credentialsProvider: credentials)
+        participantService?.addUserAgentProductToken("AmazonConnect-Mobile Chat-iOS SDK/\(CommonUtils.getLibraryVersion())")
         
         AWSConnectParticipant.register(with: participantService!, forKey: Constants.AWSConnectParticipantKey)
         

--- a/Sources/Core/Network/MessageReceiptsManager.swift
+++ b/Sources/Core/Network/MessageReceiptsManager.swift
@@ -11,6 +11,7 @@ protocol MessageReceiptsManagerProtocol {
     func throttleAndSendMessageReceipt(event: MessageReceiptType, messageId: String, completion: @escaping (Result<PendingMessageReceipts, Error>) -> Void)
     func invalidateTimer() -> Void
     func handleMessageReceipt(event: MessageReceiptType, messageId: String)
+    func reset() -> Void
 }
 
 struct PendingMessageReceipts {
@@ -96,5 +97,11 @@ class MessageReceiptsManager: MessageReceiptsManagerProtocol {
             pendingMessageReceipts.readReceiptMessageId = messageId
             break
         }
+    }
+    
+    func reset() {
+        self.readReceiptSet.removeAll()
+        self.deliveredReceiptSet.removeAll()
+        self.pendingMessageReceipts.clear()
     }
 }

--- a/Sources/Core/Service/ChatSession.swift
+++ b/Sources/Core/Service/ChatSession.swift
@@ -90,6 +90,8 @@ public protocol ChatSessionProtocol {
     /// Returns a boolean indicating whether the chat session is still active.
     func isChatSessionActive() -> Bool
     
+    func reset() -> Void
+    
     var onConnectionEstablished: (() -> Void)? { get set }
     var onConnectionReEstablished: (() -> Void)? { get set }
     var onConnectionBroken: (() -> Void)? { get set }
@@ -314,6 +316,12 @@ public class ChatSession: ChatSessionProtocol {
                 completion(result)
             }
         }
+    }
+    
+    public func reset() {
+        chatService.reset()
+        self.cleanupSubscriptions()
+        ConnectionDetailsProvider.shared.setChatSessionState(isActive: false)
     }
     
     /// Cleans up subscriptions when the chat session is deinitialized.

--- a/Sources/Core/Service/ChatSession.swift
+++ b/Sources/Core/Service/ChatSession.swift
@@ -25,12 +25,13 @@ public protocol ChatSessionProtocol {
     func disconnect(completion: @escaping (Result<Void, Error>) -> Void)
     
     /// Disconnects the websocket and suspends reconnection attempts.
-    /// - Parameter completion: The completion handler to call when the suspend operation is complete.
-    func suspendWebSocketConnection()
+    func suspendWebSocketConnection() -> Void
     
     /// Resumes a suspended websocket and attempts to reconnect.
-    /// - Parameter completion: The completion handler to call when the resume operation is complete.
-    func resumeWebSocketConnection()
+    func resumeWebSocketConnection() -> Void
+
+    /// Resets the ChatSession state which will disconnect the webSocket and remove all session related data without disconnecting the participant from the chat contact.
+    func reset() -> Void
     
     /// Sends a message within the chat session.
     /// - Parameters:
@@ -89,8 +90,6 @@ public protocol ChatSessionProtocol {
     
     /// Returns a boolean indicating whether the chat session is still active.
     func isChatSessionActive() -> Bool
-    
-    func reset() -> Void
     
     var onConnectionEstablished: (() -> Void)? { get set }
     var onConnectionReEstablished: (() -> Void)? { get set }

--- a/Sources/Core/Utils/CommonUtils.swift
+++ b/Sources/Core/Utils/CommonUtils.swift
@@ -40,7 +40,6 @@ struct CommonUtils {
     }
     
     static func getLibraryVersion() -> String {
-        // Update manually per release
         return "1.0.6"
     }
 }

--- a/Sources/Core/Utils/CommonUtils.swift
+++ b/Sources/Core/Utils/CommonUtils.swift
@@ -39,4 +39,8 @@ struct CommonUtils {
         return isoFormatter.string(from: currentDate)
     }
     
+    static func getLibraryVersion() -> String {
+        // Update manually per release
+        return "1.0.6"
+    }
 }

--- a/Sources/Core/Utils/ConnectionDetailsProvider.swift
+++ b/Sources/Core/Utils/ConnectionDetailsProvider.swift
@@ -10,6 +10,7 @@ public protocol ConnectionDetailsProviderProtocol {
     func getChatDetails() -> ChatDetails?
     func isChatSessionActive() -> Bool
     func setChatSessionState(isActive: Bool) -> Void
+    func reset() -> Void
 }
 
 class ConnectionDetailsProvider: ConnectionDetailsProviderProtocol {
@@ -42,6 +43,12 @@ class ConnectionDetailsProvider: ConnectionDetailsProviderProtocol {
     
     func setChatSessionState(isActive: Bool) -> Void {
         self.isChatActive = isActive
+    }
+    
+    func reset() {
+        self.connectionDetails = nil
+        self.chatDetails = nil
+        self.isChatActive = false
     }
 
     // Additional logic to handle connection details lifecycle


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR introduces a new API: `ChatSession.reset`.  This API will remove all in-memory user session data such as internal transcript and tokens.  This will also disconnect the websocket connection.

This PR also adds a new user agent suffix configuration for the connect participant client. Here is an example UA string:

```
aws-sdk-iOS/2.40.1 iOS/18.1 en_US  AmazonConnect-Mobile Chat-iOS SDK/1.0.6
```

Note that the version will need to be updated manually in the `CommonUtils.swift` file each release.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO] NO

*Does this change introduce any new dependency?* [YES/NO]. NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

YES

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

