### PR TITLE
Fixing issue that message metadata is missing in getTranscript

### DIFF
--- a/Sources/Core/Models/ChatEvent.swift
+++ b/Sources/Core/Models/ChatEvent.swift
@@ -16,6 +16,7 @@ public enum ContentType: String {
     case plainText = "text/plain"
     case richText = "text/markdown"
     case interactiveText = "application/vnd.amazonaws.connect.message.interactive"
+    case interactiveResponse = "application/vnd.amazonaws.connect.message.interactive.response"
 }
 
 public enum MessageReceiptType: String {

--- a/Sources/Core/Network/WebSocketManager.swift
+++ b/Sources/Core/Network/WebSocketManager.swift
@@ -398,7 +398,8 @@ extension WebsocketManager {
                 "Type": CommonUtils().convertParticipantTypeToString(item.types.rawValue),
                 "DisplayName": item.displayName ?? "",
                 "Attachments": attachmentsArray,
-                "IsFromPastSession": true // Mark all these items as coming from a past session
+                "IsFromPastSession": true, // Mark all these items as coming from a past session
+                "MessageMetadata": CommonUtils().convertMessageMetadataToDict(item.messageMetadata)
             ]
             
             // Serialize the dictionary to JSON string
@@ -446,7 +447,8 @@ extension WebsocketManager {
             timeStamp: time,
             messageId: messageId,
             displayName: displayName,
-            serializedContent: serializedContent
+            serializedContent: serializedContent,
+            metadata: (innerJson["MessageMetadata"] != nil) ? handleMetadata(innerJson, serializedContent) as? (any MetadataProtocol) : nil
         )
     }
     

--- a/Sources/Core/Utils/CommonUtils.swift
+++ b/Sources/Core/Utils/CommonUtils.swift
@@ -32,6 +32,23 @@ struct CommonUtils {
         }
     }
     
+    func convertMessageMetadataToDict(_ messageMetadata: AWSConnectParticipantMessageMetadata?) -> [String: Any] {
+        guard let messageId = messageMetadata?.messageId else {
+            return [:]
+        }
+        
+        return [
+            "MessageId": messageId,
+            "Receipts": messageMetadata?.receipts?.compactMap { receipt in
+                return [
+                    "ReadTimestamp": receipt.readTimestamp ?? "",
+                    "DeliveredTimestamp": receipt.deliveredTimestamp ?? "",
+                    "RecipientParticipantId": receipt.recipientParticipantId ?? ""
+                ]
+            } ?? []
+        ]
+    }
+    
     static func getCurrentISOTime() -> String {
         let currentDate = Date()
         let isoFormatter = ISO8601DateFormatter()


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*
  * Fixing issue that message metadata is missing in getTranscript
  * Adding interactiveResponse content type.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [NO]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?*
No

*Have you tested the changes with a sample UI?*
Yes

*List manual testing steps:*
 - Add Steps below: 
   - started a chat a accepted from agent CCP
   - sent messages from customer and read them from CCP, confirmed read receipts were displayed
   - closed the app, then opened it again and reconnected to the existing chat to trigger a getTranscript, verified read receipts were still there

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

