### PR TITLE
Fixing metadata bug + updating version

### DIFF
--- a/Sources/Core/Utils/CommonUtils.swift
+++ b/Sources/Core/Utils/CommonUtils.swift
@@ -41,9 +41,9 @@ struct CommonUtils {
             "MessageId": messageId,
             "Receipts": messageMetadata?.receipts?.compactMap { receipt in
                 return [
-                    "ReadTimestamp": receipt.readTimestamp ?? "",
-                    "DeliveredTimestamp": receipt.deliveredTimestamp ?? "",
-                    "RecipientParticipantId": receipt.recipientParticipantId ?? ""
+                    "ReadTimestamp": receipt.readTimestamp ?? nil,
+                    "DeliveredTimestamp": receipt.deliveredTimestamp ?? nil,
+                    "RecipientParticipantId": receipt.recipientParticipantId ?? nil
                 ]
             } ?? []
         ]
@@ -57,6 +57,6 @@ struct CommonUtils {
     }
     
     static func getLibraryVersion() -> String {
-        return "1.0.6"
+        return "1.0.7"
     }
 }


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

There is an existing issue where if there is a message with a delivered receipt when we disconnect the chat, it will become a read receipt when we re-connect to the chat. This is because we check if it is read based on whether the read timestamp is a string, and even in the case where the read receipt is missing, we initialize it to an empty string.  This PR updates so that it is set to nil if it is not received.

We are also bumping the version to prepare for a release. 

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*
NA

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

