### PR TITLE
Remove duplicate getTranscript call on reconnect

### DIFF
--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -92,9 +92,6 @@ class ChatService : ChatServiceProtocol {
                     ConnectionDetailsProvider.shared.setChatSessionState(isActive: true)
                     self?.getTranscript() {_ in }
                 }
-                if (event == .connectionEstablished){
-                    self?.getTranscript{ _ in}
-                }
                 if (event == .connectionReEstablished){
                     self?.fetchReconnectedTranscript()
                 }


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

We are making two `getTranscript` calls whenever we re-connect to a chat session.  This is due to the additional `event == .connectionEstablished` check in `setupWebSocket`.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*
NA

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*
YES

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

