### PR TITLE
Updating transcriptListPublisher to pass back previousTranscriptNextToken

### DIFF
--- a/AmazonConnectChatIOSTests/Core/Service/ChatServiceTests.swift
+++ b/AmazonConnectChatIOSTests/Core/Service/ChatServiceTests.swift
@@ -768,38 +768,6 @@ class ChatServiceTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
     
-    func testfetchReconnectedTranscript_Success() {
-        let chatDetails = createChatDetails()
-        
-        mockAWSClient.createParticipantConnectionResult = .success(createConnectionDetails())
-        
-        let transcriptItem = AWSConnectParticipantItem()
-        transcriptItem!.identifier = "testId"
-        transcriptItem!.content = "testContent"
-        
-        let response = AWSConnectParticipantGetTranscriptResponse()!
-        response.transcript = [transcriptItem!]
-        response.nextToken = "testNextToken"
-        
-        mockAWSClient.getTranscriptResult = .success(response)
-        
-        let expectation = self.expectation(description: "Transcript should be retrieved successfully")
-        
-        // Create the chat session to ensure WebSocket is set up
-        chatService.createChatSession(chatDetails: chatDetails) { success, error in
-            XCTAssertTrue(success, "Chat session should be created successfully")
-            XCTAssertNil(error, "Error should be nil")
-            self.chatService.internalTranscript = [TranscriptItem(timeStamp: "testContent", contentType: "text/plain", id: "testId", serializedContent: [:])]
-            self.chatService.fetchReconnectedTranscript()
-            
-            // Expect getTranscript to be called once since transcript response ID is the same as internal transcript ID
-            XCTAssertEqual(self.mockAWSClient.numGetTranscriptCalled, 1)
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 1)
-    }
-    
     func testRegisterNotificationListeners() {
         let expectation = self.expectation(description: "Should receive new WebSocket URL")
         

--- a/AmazonConnectChatIOSTests/Core/Service/ChatServiceTests.swift
+++ b/AmazonConnectChatIOSTests/Core/Service/ChatServiceTests.swift
@@ -132,7 +132,7 @@ class ChatServiceTests: XCTestCase {
         
         var isExpectationFulfilled = false
         let cancellable = chatService.subscribeToTranscriptList { items in
-            receivedItems = items
+            receivedItems = items.transcriptList
             if !isExpectationFulfilled {
                 expectation.fulfill()
                 isExpectationFulfilled = true
@@ -140,7 +140,7 @@ class ChatServiceTests: XCTestCase {
         }
         
         let transcriptItem = TranscriptItem(timeStamp: "timestamp", contentType: "text/plain", id: "12345", serializedContent: ["content": "testContent"])
-        chatService.transcriptListPublisher.send([transcriptItem])
+        chatService.transcriptListPublisher.send(TranscriptData(transcriptList: [transcriptItem], previousTranscriptNextToken: nil))
         
         waitForExpectations(timeout: 1) { error in
             if let error = error {
@@ -546,6 +546,7 @@ class ChatServiceTests: XCTestCase {
         
         let response = AWSConnectParticipantGetTranscriptResponse()!
         response.transcript = [transcriptItem!]
+        response.nextToken = "testToken"
         
         mockAWSClient.getTranscriptResult = .success(response)
         
@@ -562,6 +563,7 @@ class ChatServiceTests: XCTestCase {
                 case .success(let transcriptResponse):
                     XCTAssertEqual(transcriptResponse.transcript.count, 1, "Retrieved items should match expected items count")
                     XCTAssertEqual(transcriptResponse.transcript.first?.serializedContent?["content"] as! String, "testContent", "Retrieved content should match expected content")
+                    XCTAssertEqual(self.chatService.previousTranscriptNextToken, response.nextToken, "previousTranscriptNextToken should be set to the response's nextToken")
                 case .failure(let error):
                     XCTFail("Unexpected failure: \(error)")
                 }
@@ -606,6 +608,161 @@ class ChatServiceTests: XCTestCase {
                 XCTAssertEqual(error as NSError?, noConnectionDetailsError, "Should receive the expected error for no connection details")
             }
             expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+
+    func testfetchReconnectedTranscript_Success() {
+        let chatDetails = createChatDetails()
+        
+        mockAWSClient.createParticipantConnectionResult = .success(createConnectionDetails())
+        
+        let transcriptItem = AWSConnectParticipantItem()
+        transcriptItem!.identifier = "testId"
+        transcriptItem!.content = "testContent"
+        
+        let response = AWSConnectParticipantGetTranscriptResponse()!
+        response.transcript = [transcriptItem!]
+        response.nextToken = "testNextToken"
+        
+        mockAWSClient.getTranscriptResult = .success(response)
+        
+        let expectation = self.expectation(description: "Transcript should be retrieved successfully")
+        
+        // Create the chat session to ensure WebSocket is set up
+        chatService.createChatSession(chatDetails: chatDetails) { success, error in
+            XCTAssertTrue(success, "Chat session should be created successfully")
+            XCTAssertNil(error, "Error should be nil")
+            self.chatService.internalTranscript = [TranscriptItem(timeStamp: "testContent", contentType: "text/plain", id: "testId", serializedContent: [:])]
+            self.chatService.fetchReconnectedTranscript()
+            
+            // Expect getTranscript to be called once since transcript response ID is the same as internal transcript ID
+            XCTAssertEqual(self.mockAWSClient.numGetTranscriptCalled, 1)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testGetTranscript_previousNextTokenUpdate_wontUpdateOnNewerMessage() {
+        let chatDetails = createChatDetails()
+        
+        mockAWSClient.createParticipantConnectionResult = .success(createConnectionDetails())
+        
+        let transcriptItem = AWSConnectParticipantItem()
+        transcriptItem?.absoluteTime = "2025-04-01T20:38:15.204Z"
+        transcriptItem!.content = "testContent"
+        
+        let response = AWSConnectParticipantGetTranscriptResponse()!
+        response.transcript = [transcriptItem!]
+        response.nextToken = "testToken"
+        
+        chatService.internalTranscript.append(TranscriptItem(timeStamp: "2024-04-01T20:38:15.204Z", contentType: "text/plain", id: "1234", serializedContent: nil))
+        
+        mockAWSClient.getTranscriptResult = .success(response)
+        
+        let expectation = self.expectation(description: "Transcript should be retrieved successfully")
+        
+        // Create the chat session to ensure WebSocket is set up
+        chatService.createChatSession(chatDetails: chatDetails) { success, error in
+            XCTAssertTrue(success, "Chat session should be created successfully")
+            XCTAssertNil(error, "Error should be nil")
+            
+            // Get the transcript after the chat session is created
+            self.chatService.getTranscript(scanDirection: .backward, sortOrder: .ascending, maxResults: 15, nextToken: nil, startPosition: nil) { result in
+                switch result {
+                case .success(let transcriptResponse):
+                    XCTAssertEqual(transcriptResponse.transcript.count, 1, "Retrieved items should match expected items count")
+                    XCTAssertEqual(transcriptResponse.transcript.first?.serializedContent?["content"] as! String, "testContent", "Retrieved content should match expected content")
+                    XCTAssertEqual(self.chatService.previousTranscriptNextToken, nil)
+                case .failure(let error):
+                    XCTFail("Unexpected failure: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testGetTranscript_previousNextTokenUpdate_updateOnOlderMessage() {
+        let chatDetails = createChatDetails()
+        
+        mockAWSClient.createParticipantConnectionResult = .success(createConnectionDetails())
+        
+        let transcriptItem = AWSConnectParticipantItem()
+        transcriptItem?.absoluteTime = "2024-04-01T20:38:15.204Z"
+        transcriptItem!.content = "testContent"
+        
+        let response = AWSConnectParticipantGetTranscriptResponse()!
+        response.transcript = [transcriptItem!]
+        response.nextToken = "testToken"
+        
+        chatService.internalTranscript.append(TranscriptItem(timeStamp: "2025-04-01T20:38:15.204Z", contentType: "text/plain", id: "1234", serializedContent: nil))
+        
+        mockAWSClient.getTranscriptResult = .success(response)
+        
+        let expectation = self.expectation(description: "Transcript should be retrieved successfully")
+        
+        // Create the chat session to ensure WebSocket is set up
+        chatService.createChatSession(chatDetails: chatDetails) { success, error in
+            XCTAssertTrue(success, "Chat session should be created successfully")
+            XCTAssertNil(error, "Error should be nil")
+            
+            // Get the transcript after the chat session is created
+            self.chatService.getTranscript(scanDirection: .backward, sortOrder: .ascending, maxResults: 15, nextToken: nil, startPosition: nil) { result in
+                switch result {
+                case .success(let transcriptResponse):
+                    XCTAssertEqual(transcriptResponse.transcript.count, 1, "Retrieved items should match expected items count")
+                    XCTAssertEqual(transcriptResponse.transcript.first?.serializedContent?["content"] as! String, "testContent", "Retrieved content should match expected content")
+                    XCTAssertEqual(self.chatService.previousTranscriptNextToken, response.nextToken)
+                case .failure(let error):
+                    XCTFail("Unexpected failure: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+
+    func testGetTranscript_previousNextTokenUpdate_wontUpdateOnForwardScan() {
+        let chatDetails = createChatDetails()
+        
+        mockAWSClient.createParticipantConnectionResult = .success(createConnectionDetails())
+        
+        let transcriptItem = AWSConnectParticipantItem()
+        transcriptItem?.absoluteTime = "2024-04-01T20:38:15.204Z"
+        transcriptItem!.content = "testContent"
+        
+        let response = AWSConnectParticipantGetTranscriptResponse()!
+        response.transcript = [transcriptItem!]
+        response.nextToken = "testToken"
+        
+        chatService.internalTranscript.append(TranscriptItem(timeStamp: "2025-04-01T20:38:15.204Z", contentType: "text/plain", id: "1234", serializedContent: nil))
+        
+        mockAWSClient.getTranscriptResult = .success(response)
+        
+        let expectation = self.expectation(description: "Transcript should be retrieved successfully")
+        
+        // Create the chat session to ensure WebSocket is set up
+        chatService.createChatSession(chatDetails: chatDetails) { success, error in
+            XCTAssertTrue(success, "Chat session should be created successfully")
+            XCTAssertNil(error, "Error should be nil")
+            
+            // Get the transcript after the chat session is created
+            self.chatService.getTranscript(scanDirection: .forward, sortOrder: .ascending, maxResults: 15, nextToken: nil, startPosition: nil) { result in
+                switch result {
+                case .success(let transcriptResponse):
+                    XCTAssertEqual(transcriptResponse.transcript.count, 1, "Retrieved items should match expected items count")
+                    XCTAssertEqual(transcriptResponse.transcript.first?.serializedContent?["content"] as! String, "testContent", "Retrieved content should match expected content")
+                    XCTAssertEqual(self.chatService.previousTranscriptNextToken, nil)
+                case .failure(let error):
+                    XCTFail("Unexpected failure: \(error)")
+                }
+                expectation.fulfill()
+            }
         }
         
         waitForExpectations(timeout: 1)

--- a/README.md
+++ b/README.md
@@ -461,10 +461,10 @@ var onMessageReceived: ((TranscriptItem) -> Void)? { get set }
 --------------------
 
 #### `ChatSession.onTranscriptUpdated`
-Callback for when the transcript is updated. See [TranscriptItem](#transcriptitem)
+Callback for when the transcript is updated. See [TranscriptData](#transcriptdata)
 
 ```
-var onTranscriptUpdated: (([TranscriptItem]) -> Void)? { get set }
+var onTranscriptUpdated: ((TranscriptData) -> Void)? { get set }
 ```
 
 --------------------
@@ -693,6 +693,23 @@ public class TranscriptItem: TranscriptItemProtocol {
 * `serializedContent`
   * The raw JSON format of the received WebSocket message
   * Type: Array of `String: Any`
+
+--------
+### TranscriptData
+This is the object that is passed back to the registered [ChatSession.onTranscriptUpdated](#chatsessionontranscriptupdated) event handler
+
+```
+public struct TranscriptData {
+    public let transcriptList: [TranscriptItem]
+    public let previousTranscriptNextToken: String?
+}
+```
+* `transcriptList`
+  * The current in-memory transcript list.
+  * Type: Array of `TranscriptItem`
+* `previousTranscriptNextToken`
+  * This is a next token that is used as a `getTranscript` argument to retrieve older messages.  This will be `nil` if there are no more available messages to fetch from the top of the currently loaded transcript.
+  * Type: `String`
 
 --------
 ### Message (extends [TranscriptItem](#transcriptitem))

--- a/Sources/Core/Models/TranscriptItem.swift
+++ b/Sources/Core/Models/TranscriptItem.swift
@@ -42,3 +42,8 @@ public class TranscriptItem: TranscriptItemProtocol {
         self.timeStamp = newTimeStamp
     }
 }
+
+public struct TranscriptData {
+    public let transcriptList: [TranscriptItem]
+    public let previousTranscriptNextToken: String?
+}

--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -21,7 +21,7 @@ protocol ChatServiceProtocol {
     func getAttachmentDownloadUrl(attachmentId: String, completion: @escaping (Result<URL, Error>) -> Void)
     func subscribeToEvents(handleEvent: @escaping (ChatEvent) -> Void) -> AnyCancellable
     func subscribeToTranscriptItem(handleTranscriptItem: @escaping (TranscriptItem) -> Void) -> AnyCancellable
-    func subscribeToTranscriptList(handleTranscriptList: @escaping ([TranscriptItem]) -> Void) -> AnyCancellable
+    func subscribeToTranscriptList(handleTranscriptList: @escaping (TranscriptData) -> Void) -> AnyCancellable
     func getTranscript(scanDirection: AWSConnectParticipantScanDirection?, sortOrder: AWSConnectParticipantSortKey?, maxResults: NSNumber?, nextToken: String?, startPosition: AWSConnectParticipantStartPosition?, completion: @escaping (Result<TranscriptResponse, Error>) -> Void)
     func configure(config: GlobalConfig)
     func getConnectionDetailsProvider() -> ConnectionDetailsProviderProtocol
@@ -31,12 +31,13 @@ protocol ChatServiceProtocol {
 class ChatService : ChatServiceProtocol {
     var eventPublisher = PassthroughSubject<ChatEvent, Never>()
     var transcriptItemPublisher = PassthroughSubject<TranscriptItem, Never>()
-    var transcriptListPublisher = CurrentValueSubject<[TranscriptItem], Never>([])
+    var transcriptListPublisher = CurrentValueSubject<(TranscriptData), Never>(TranscriptData(transcriptList:[], previousTranscriptNextToken: nil))
     var urlSession = URLSession(configuration: .default)
     var apiClient: APIClientProtocol = APIClient.shared
     var messageReceiptsManager: MessageReceiptsManagerProtocol?
     var websocketManager: WebsocketManagerProtocol?
     var internalTranscript: [TranscriptItem] = []
+    var previousTranscriptNextToken: String? = nil
     private var eventCancellables = Set<AnyCancellable>()
     private var transcriptItemCancellables = Set<AnyCancellable>()
     private var transcriptListCancellables = Set<AnyCancellable>()
@@ -51,7 +52,7 @@ class ChatService : ChatServiceProtocol {
     private var attachmentIdToTempMessageIdMap: [String: String] = [:]
     private var transcriptDict: [String: TranscriptItem] = [:]
     private var tempMessageIdToFileUrl: [String: URL] = [:]
-    
+    private var transcriptListUpdateDebounceTimer: Timer?
     
     init(awsClient: AWSClientProtocol = AWSClient.shared,
         connectionDetailsProvider: ConnectionDetailsProviderProtocol = ConnectionDetailsProvider.shared,
@@ -198,7 +199,7 @@ class ChatService : ChatServiceProtocol {
         }
         
         if transcriptDict.count != initialCount {
-            transcriptListPublisher.send(internalTranscript)
+            transcriptListPublisher.send(TranscriptData(transcriptList: internalTranscript, previousTranscriptNextToken: nil))
         }
     }
     
@@ -225,15 +226,20 @@ class ChatService : ChatServiceProtocol {
             }
         }
         
-        // Send out updated transcript
-        self.transcriptListPublisher.send(internalTranscript)
+        // Reduce frequency of published transcriptList updates
+        transcriptListUpdateDebounceTimer?.invalidate()
+        transcriptListUpdateDebounceTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: false) { [weak self] _ in
+            guard let self = self else { return }
+            // Send out updated transcript
+            self.transcriptListPublisher.send(TranscriptData(transcriptList: internalTranscript, previousTranscriptNextToken: previousTranscriptNextToken))
+        }
     }
     
-    func subscribeToTranscriptList(handleTranscriptList: @escaping ([TranscriptItem]) -> Void) -> AnyCancellable {
+    func subscribeToTranscriptList(handleTranscriptList: @escaping (TranscriptData) -> Void) -> AnyCancellable {
         let subscription = transcriptListPublisher
             .receive(on: RunLoop.main)
-            .sink(receiveValue: { updatedTranscript in
-                handleTranscriptList(updatedTranscript)
+            .sink(receiveValue: { transcriptData in
+                handleTranscriptList(transcriptData)
             })
         transcriptListCancellables.insert(subscription)
         return subscription
@@ -331,7 +337,7 @@ class ChatService : ChatServiceProtocol {
                 transcriptDict.removeValue(forKey: oldId)
                 internalTranscript.removeAll { $0.id == oldId }
                 // Send out updated transcript
-                self.transcriptListPublisher.send(internalTranscript)
+                self.transcriptListPublisher.send(TranscriptData(transcriptList: internalTranscript, previousTranscriptNextToken: previousTranscriptNextToken))
             } else {
                 // Update the placeholder message's ID to the new ID
                 placeholderMessage.updateId(newId)
@@ -358,7 +364,7 @@ class ChatService : ChatServiceProtocol {
         internalTranscript.removeAll { $0.id == messageId }
         transcriptDict.removeValue(forKey: messageId)
         // Send out updated transcript with old message removed
-        self.transcriptListPublisher.send(internalTranscript)
+        self.transcriptListPublisher.send(TranscriptData(transcriptList: internalTranscript, previousTranscriptNextToken: previousTranscriptNextToken))
 
         // as the next step, attempt to resend the message based on its type
         // if old message is an attachment
@@ -756,6 +762,29 @@ class ChatService : ChatServiceProtocol {
                     return
                 }
                 
+                let isStartPositionDefined = getTranscriptArgs?.startPosition != nil &&
+                    (getTranscriptArgs?.startPosition?.identifier != nil ||
+                     getTranscriptArgs?.startPosition?.absoluteTime != nil ||
+                     getTranscriptArgs?.startPosition?.mostRecent != nil
+                    )
+                
+                // Ignore setting previousTranscriptNextToken if items aren't going from newest -> oldest.
+                // We also ignore if getTranscript is called with a start position but returns empty transcript
+                // since that is indicative of an invalid StartPosition.
+                if getTranscriptArgs?.scanDirection == .backward || !(isStartPositionDefined && transcriptItems.isEmpty) {
+                    if let internalTranscript = self?.internalTranscript, internalTranscript.isEmpty || transcriptItems.isEmpty {
+                        self?.previousTranscriptNextToken = response.nextToken
+                        self?.transcriptListPublisher.send(TranscriptData(transcriptList: internalTranscript, previousTranscriptNextToken: self?.previousTranscriptNextToken))
+                    } else {
+                        let oldestTranscriptItem = getTranscriptArgs?.sortOrder == .ascending ? transcriptItems.first : transcriptItems.last
+                        let oldestInternalTranscriptItem = self?.internalTranscript.first
+                        
+                        if let firstTranscriptItemTime = oldestTranscriptItem?.absoluteTime, let firstInternalTranscriptItemTime = oldestInternalTranscriptItem?.timeStamp, firstTranscriptItemTime <= firstInternalTranscriptItemTime {
+                            self?.previousTranscriptNextToken = response.nextToken
+                        }
+                    }
+                }
+                
                 if let websocketManager = self?.websocketManager {
                     let formattedItems = websocketManager.formatAndProcessTranscriptItems(transcriptItems)
                     let transcriptResponse = TranscriptResponse(
@@ -817,7 +846,7 @@ class ChatService : ChatServiceProtocol {
         
         eventPublisher = PassthroughSubject<ChatEvent, Never>()
         transcriptItemPublisher = PassthroughSubject<TranscriptItem, Never>()
-        transcriptListPublisher = CurrentValueSubject<[TranscriptItem], Never>([])
+        transcriptListPublisher = CurrentValueSubject<TranscriptData, Never>(TranscriptData(transcriptList:[], previousTranscriptNextToken: nil))
         transcriptItemSet = Set<String>()
         transcriptDict = [:]
         internalTranscript = []

--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -771,7 +771,7 @@ class ChatService : ChatServiceProtocol {
                 // Ignore setting previousTranscriptNextToken if items aren't going from newest -> oldest.
                 // We also ignore if getTranscript is called with a start position but returns empty transcript
                 // since that is indicative of an invalid StartPosition.
-                if getTranscriptArgs?.scanDirection == .backward || !(isStartPositionDefined && transcriptItems.isEmpty) {
+                if getTranscriptArgs?.scanDirection == .backward && !(isStartPositionDefined && transcriptItems.isEmpty) {
                     if let internalTranscript = self?.internalTranscript, internalTranscript.isEmpty || transcriptItems.isEmpty {
                         self?.previousTranscriptNextToken = response.nextToken
                         self?.transcriptListPublisher.send(TranscriptData(transcriptList: internalTranscript, previousTranscriptNextToken: self?.previousTranscriptNextToken))

--- a/Sources/Core/Service/ChatSession.swift
+++ b/Sources/Core/Service/ChatSession.swift
@@ -95,7 +95,7 @@ public protocol ChatSessionProtocol {
     var onConnectionReEstablished: (() -> Void)? { get set }
     var onConnectionBroken: (() -> Void)? { get set }
     var onMessageReceived: ((TranscriptItem) -> Void)? { get set }
-    var onTranscriptUpdated: (([TranscriptItem]) -> Void)? { get set }
+    var onTranscriptUpdated: ((TranscriptData) -> Void)? { get set }
     var onChatEnded: (() -> Void)? { get set }
     var onDeepHeartbeatFailure: (() -> Void)? { get set }
 }
@@ -111,7 +111,7 @@ public class ChatSession: ChatSessionProtocol {
     public var onConnectionReEstablished: (() -> Void)?
     public var onConnectionBroken: (() -> Void)?
     public var onMessageReceived: ((TranscriptItem) -> Void)?
-    public var onTranscriptUpdated: (([TranscriptItem]) -> Void)?
+    public var onTranscriptUpdated: ((TranscriptData) -> Void)?
     public var onChatEnded: (() -> Void)?
     public var onDeepHeartbeatFailure: (() -> Void)?
     
@@ -148,10 +148,10 @@ public class ChatSession: ChatSessionProtocol {
             }
         }
         
-        transcriptSubscription = chatService.subscribeToTranscriptList { [weak self] transcriptList in
+        transcriptSubscription = chatService.subscribeToTranscriptList { [weak self] transcriptData in
             DispatchQueue.main.async {
-                if !transcriptList.isEmpty {
-                    self?.onTranscriptUpdated?(transcriptList)
+                if !transcriptData.transcriptList.isEmpty {
+                    self?.onTranscriptUpdated?(transcriptData)
                 }
             }
         }

--- a/Sources/Core/Utils/CommonUtils.swift
+++ b/Sources/Core/Utils/CommonUtils.swift
@@ -57,6 +57,6 @@ struct CommonUtils {
     }
     
     static func getLibraryVersion() -> String {
-        return "1.0.7"
+        return "2.0.0"
     }
 }


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR updates the `transcriptListPublisher` logic.
- Returns `TranscriptData` object which contains the original `transcriptList` property as well as a `previousTranscriptNextToken` string property.
    - `previousTranscriptNextToken` represents the `nextToken` that will fetch the next batch of older transcripts
- Adding debounce to `transcriptListPublisher` updates to reduce the number of handler calls.  Original behavior would call the update event for each message in a `getTranscript` result (i.e. if `getTranscript` returned 100 messages, it would trigger 100 times).

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

YES

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

