### PR TITLE
Fix getTranscript Loop on reconnection flow

### DIFF
--- a/AmazonConnectChatIOSTests/Core/Network/Mocks/MockAWSClient.swift
+++ b/AmazonConnectChatIOSTests/Core/Network/Mocks/MockAWSClient.swift
@@ -15,6 +15,7 @@ class MockAWSClient: AWSClientProtocol {
     var completeAttachmentUploadResult: Result<AWSConnectParticipantCompleteAttachmentUploadResponse, Error>?
     var getAttachmentResult: Result<AWSConnectParticipantGetAttachmentResponse, Error>?
     var numTypingEventCalled: Int = 0
+    var numGetTranscriptCalled: Int = 0
 
     func createParticipantConnection(participantToken: String, completion: @escaping (Result<ConnectionDetails, Error>) -> Void) {
         if let result = createParticipantConnectionResult {
@@ -44,6 +45,7 @@ class MockAWSClient: AWSClientProtocol {
     }
     
     func getTranscript(getTranscriptArgs: AWSConnectParticipantGetTranscriptRequest, completion: @escaping (Result<AWSConnectParticipantGetTranscriptResponse, Error>) -> Void) {
+        numGetTranscriptCalled += 1
         if let result = getTranscriptResult {
             completion(result)
         }

--- a/AmazonConnectChatIOSTests/Core/Service/ChatServiceTests.swift
+++ b/AmazonConnectChatIOSTests/Core/Service/ChatServiceTests.swift
@@ -611,6 +611,38 @@ class ChatServiceTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
     
+    func testfetchReconnectedTranscript_Success() {
+        let chatDetails = createChatDetails()
+        
+        mockAWSClient.createParticipantConnectionResult = .success(createConnectionDetails())
+        
+        let transcriptItem = AWSConnectParticipantItem()
+        transcriptItem!.identifier = "testId"
+        transcriptItem!.content = "testContent"
+        
+        let response = AWSConnectParticipantGetTranscriptResponse()!
+        response.transcript = [transcriptItem!]
+        response.nextToken = "testNextToken"
+        
+        mockAWSClient.getTranscriptResult = .success(response)
+        
+        let expectation = self.expectation(description: "Transcript should be retrieved successfully")
+        
+        // Create the chat session to ensure WebSocket is set up
+        chatService.createChatSession(chatDetails: chatDetails) { success, error in
+            XCTAssertTrue(success, "Chat session should be created successfully")
+            XCTAssertNil(error, "Error should be nil")
+            self.chatService.internalTranscript = [TranscriptItem(timeStamp: "testContent", contentType: "text/plain", id: "testId", serializedContent: [:])]
+            self.chatService.fetchReconnectedTranscript()
+            
+            // Expect getTranscript to be called once since transcript response ID is the same as internal transcript ID
+            XCTAssertEqual(self.mockAWSClient.numGetTranscriptCalled, 1)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+    
     func testRegisterNotificationListeners() {
         let expectation = self.expectation(description: "Should receive new WebSocket URL")
         


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR fixes an unexpected `getTranscript` loop regarding the re-connection flow.  The issue stems from an unexpected behavior where calling `getTranscript` in the forward direction will always return the last item and a `nextToken` even if there are no more messages.

This PR fixes this issue by changing the conditional to add another check to see whether the last returned message is already within the internal transcript.  If it is, we already know that we have fetched all available messages.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

