### PR TITLE
Add persistentId field in Message for common attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,9 +680,11 @@ public class TranscriptItem: TranscriptItemProtocol {
     public var timeStamp: String
     public var contentType: String
     public var serializedContent: [String: Any]?
+    public var persistentId: String
+}
 ```
 * `id`
-  * Id for the message. Unique to each message in the transcript.
+  * Id for the message. Unique to each message in the transcript. Id can be used only for the ACPS APIs requests.
   * Type: `String`
 * `timeStamp`
   * Time when the message or event was sent. Formatted in ISO 8601 (e.g. `yyyy-MM-ddThh:mm:ss.SSSZ` or ` 2019-11-08T02:41:28.172Z`)
@@ -693,6 +695,9 @@ public class TranscriptItem: TranscriptItemProtocol {
 * `serializedContent`
   * The raw JSON format of the received WebSocket message
   * Type: Array of `String: Any`
+* `persistentId`
+  * Id for the message, Unique to each message throughout chat session. This can be used only for tracking purposes by the client.
+  * Type: `String`
 
 --------
 ### TranscriptData

--- a/Sources/Core/Models/Message.swift
+++ b/Sources/Core/Models/Message.swift
@@ -27,7 +27,7 @@ public class Message: TranscriptItem, MessageProtocol {
     @Published public var metadata: (any MetadataProtocol)?
 
     public init(participant: String, text: String, contentType: String, messageDirection: MessageDirection? = nil, timeStamp: String, attachmentId: String? = nil, messageId: String? = nil,
-                displayName: String? = nil, serializedContent: [String: Any], metadata: (any MetadataProtocol)? = nil) {
+                displayName: String? = nil, serializedContent: [String: Any], metadata: (any MetadataProtocol)? = nil, persistentId: String? = nil) {
         self.participant = participant
         self.text = text
         self.messageDirection = messageDirection

--- a/Sources/Core/Models/TranscriptItem.swift
+++ b/Sources/Core/Models/TranscriptItem.swift
@@ -5,6 +5,7 @@ import Foundation
 
 public protocol TranscriptItemProtocol: Identifiable, Equatable, Hashable, ObservableObject {
     var id: String { get }
+    var persistentId: String { get }
     var timeStamp: String { get }
     var contentType: String { get set }
     var serializedContent: [String: Any]? { get set }
@@ -12,15 +13,18 @@ public protocol TranscriptItemProtocol: Identifiable, Equatable, Hashable, Obser
 
 public class TranscriptItem: TranscriptItemProtocol {
     public private(set) var id: String
+    public private(set) var persistentId: String
     public private(set) var timeStamp: String
     public var contentType: String
     public var serializedContent: [String: Any]?
 
     public init(timeStamp: String, contentType: String, id: String?, serializedContent: [String: Any]?) {
+        let randomId = UUID().uuidString
         self.timeStamp = timeStamp
         self.contentType = contentType
         self.serializedContent = serializedContent
-        self.id = id ?? UUID().uuidString
+        self.id = id ?? randomId
+        self.persistentId = id ?? randomId
     }
 
     public static func == (lhs: TranscriptItem, rhs: TranscriptItem) -> Bool {
@@ -40,6 +44,10 @@ public class TranscriptItem: TranscriptItemProtocol {
     
     internal func updateTimeStamp(_ newTimeStamp: String) {
         self.timeStamp = newTimeStamp
+    }
+    
+    internal func updatePersistentId(_ newPersistentId: String) {
+        self.persistentId = newPersistentId
     }
 }
 

--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -215,7 +215,9 @@ class ChatService : ChatServiceProtocol {
         self.transcriptItemPublisher.send(transcriptItem)
         
         if let index = internalTranscript.firstIndex(where: { $0.id == transcriptItem.id }) {
+            let existingItem = internalTranscript[index]
             // Update existing item
+            transcriptItem.updatePersistentId(existingItem.persistentId)
             internalTranscript[index] = transcriptItem
         } else {
             // Insert new item based on timestamp comparison
@@ -336,6 +338,7 @@ class ChatService : ChatServiceProtocol {
             if transcriptDict[newId] != nil {
                 transcriptDict.removeValue(forKey: oldId)
                 internalTranscript.removeAll { $0.id == oldId }
+                transcriptDict[newId]?.updatePersistentId(oldId)
                 // Send out updated transcript
                 self.transcriptListPublisher.send(TranscriptData(transcriptList: internalTranscript, previousTranscriptNextToken: previousTranscriptNextToken))
             } else {
@@ -343,6 +346,7 @@ class ChatService : ChatServiceProtocol {
                 placeholderMessage.updateId(newId)
                 placeholderMessage.metadata?.status = .Sent
                 transcriptDict.removeValue(forKey: oldId)
+                placeholderMessage.updatePersistentId(oldId)
                 transcriptDict[newId] = placeholderMessage
             }
             transcriptItemPublisher.send(placeholderMessage)

--- a/Sources/Core/Utils/TranscriptItemUtils.swift
+++ b/Sources/Core/Utils/TranscriptItemUtils.swift
@@ -19,6 +19,7 @@ struct TranscriptItemUtils {
     
     static func createDummyMessage(content: String, contentType: String, status: MessageStatus, attachmentId: String? = nil, displayName: String) -> Message {
         let isoTime = CommonUtils.getCurrentISOTime()
+        let randomId = UUID().uuidString
         
         return Message(
             participant: "CUSTOMER",
@@ -27,10 +28,11 @@ struct TranscriptItemUtils {
             messageDirection: .Outgoing,
             timeStamp: isoTime,
             attachmentId: attachmentId,
-            messageId: UUID().uuidString,
+            messageId: randomId,
             displayName: displayName,
             serializedContent: [:],
-            metadata: Metadata(status: status, timeStamp: isoTime, contentType: contentType, eventDirection: .Outgoing, serializedContent: [:])
+            metadata: Metadata(status: status, timeStamp: isoTime, contentType: contentType, eventDirection: .Outgoing, serializedContent: [:]),
+            persistentId: randomId
         )
     }
 }


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This change introduces a new field called persistentId to the Message object. The persistentId can be used by customers to consistently track messages, as it will remain the same during both message initiation and creation.
---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]
NO

*Does this change introduce any new dependency?* [YES/NO]
NO

---

### Testing:
*Is the code unit tested?*
No

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 
 - Initiated message creation with persistentId set to the same value as message Id.
 - Verified that transcript messages retain the same persistentId during message creation

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

