### PR TITLE
[DRAFT] feat(logger): add runtime toggle for SDK logging

### DIFF
--- a/AmazonConnectChatIOS.podspec
+++ b/AmazonConnectChatIOS.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
   spec.name          = 'AmazonConnectChatIOS'
-  spec.version       = '2.0.0'
+  spec.version       = '2.0.1'
   spec.license       = { :type => 'Apache License, Version 2.0', :file => "LICENSE" }
   spec.homepage      = 'https://github.com/amazon-connect/amazon-connect-chat-ios'
   spec.authors       = { 'Amazon Web Services' => 'amazonwebservices' }
   spec.summary       = 'Amazon Connect Chat SDK for iOS ...'
-  spec.source        = { :git => 'https://github.com/amazon-connect/amazon-connect-chat-ios', :tag => 'v2.0.0' }
+  spec.source        = { :git => 'https://github.com/amazon-connect/amazon-connect-chat-ios', :tag => 'v2.0.1' }
   spec.platform      = :ios, '15.0'
   spec.source_files  = "Sources/Core/**/*.{swift}"
   spec.dependency 'AWSConnectParticipant'

--- a/AmazonConnectChatIOSTests/Core/Service/ChatServiceTests.swift
+++ b/AmazonConnectChatIOSTests/Core/Service/ChatServiceTests.swift
@@ -52,10 +52,10 @@ class ChatServiceTests: XCTestCase {
         do {
             if FileManager.default.fileExists(atPath: deleteUrl.path) {
                 try FileManager.default.removeItem(at: deleteUrl)
-                print("Temp file successfully cleared")
+                SDKLogger.logger.logDebug("Temp file successfully cleared")
             }
         } catch {
-            print("Failed to remove test file: \(error.localizedDescription)")
+            SDKLogger.logger.logError("Failed to remove test file: \(error.localizedDescription)")
         }
     }
     
@@ -822,9 +822,9 @@ class ChatServiceTests: XCTestCase {
 
         do {
             try fileContents.write(to: fileUrl, atomically: true, encoding: .utf8)
-            print("File created successfully at: \(TestConstants.testFileUrl.path)")
+            SDKLogger.logger.logDebug("File created successfully at: \(TestConstants.testFileUrl.path)")
         } catch {
-            print("Failed to create file: \(error.localizedDescription)")
+            SDKLogger.logger.logError("Failed to create file: \(error.localizedDescription)")
             return
         }
         let mockAttachmentManager = MockChatService()
@@ -851,9 +851,9 @@ class ChatServiceTests: XCTestCase {
 
         do {
             try fileContents.write(to: fileUrl, atomically: true, encoding: .utf8)
-            print("File created successfully at: \(TestConstants.testFileUrl.path)")
+            SDKLogger.logger.logDebug("File created successfully at: \(TestConstants.testFileUrl.path)")
         } catch {
-            print("Failed to create file: \(error.localizedDescription)")
+            SDKLogger.logger.logError("Failed to create file: \(error.localizedDescription)")
             return
         }
         let mockAttachmentManager = MockChatService()

--- a/AmazonConnectChatIOSTests/Core/utils/SDKLoggerTests.swift
+++ b/AmazonConnectChatIOSTests/Core/utils/SDKLoggerTests.swift
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import XCTest
+@testable import AmazonConnectChatIOS
+
+class MockLogger: SDKLoggerProtocol {
+    var loggedMessages: [String] = []
+
+    func logVerbose(_ message: @autoclosure () -> String) {
+        loggedMessages.append("VERBOSE: \(message())")
+    }
+
+    func logInfo(_ message: @autoclosure () -> String) {
+        loggedMessages.append("INFO: \(message())")
+    }
+
+    func logDebug(_ message: @autoclosure () -> String) {
+        loggedMessages.append("DEBUG: \(message())")
+    }
+
+    func logFault(_ message: @autoclosure () -> String) {
+        loggedMessages.append("FAULT: \(message())")
+    }
+
+    func logError(_ message: @autoclosure () -> String) {
+        loggedMessages.append("ERROR: \(message())")
+    }
+}
+
+class SDKLoggerTests: XCTestCase {
+    var mockLogger: MockLogger!
+
+    override func setUp() {
+        super.setUp()
+        mockLogger = MockLogger()
+        SDKLogger.configureLogger(mockLogger)
+    }
+
+    override func tearDown() {
+        mockLogger = nil
+        SDKLogger.isLoggingEnabled = false
+        super.tearDown()
+    }
+
+    func testLoggingDisabledByDefault() {
+        // When
+        SDKLogger.logger.logDebug("Test message")
+
+        // Then
+        XCTAssertTrue(mockLogger.loggedMessages.isEmpty, "No messages should be logged when logging is disabled")
+    }
+
+    func testLoggingWhenEnabled() {
+        // Given
+        SDKLogger.isLoggingEnabled = true
+
+        // When
+        SDKLogger.logger.logDebug("Test debug message")
+        SDKLogger.logger.logError("Test error message")
+
+        // Then
+        XCTAssertEqual(mockLogger.loggedMessages.count, 2, "Both messages should be logged")
+        XCTAssertEqual(mockLogger.loggedMessages[0], "DEBUG: Test debug message")
+        XCTAssertEqual(mockLogger.loggedMessages[1], "ERROR: Test error message")
+    }
+
+    func testAllLogLevels() {
+        // Given
+        SDKLogger.isLoggingEnabled = true
+
+        // When
+        SDKLogger.logger.logVerbose("Verbose message")
+        SDKLogger.logger.logInfo("Info message")
+        SDKLogger.logger.logDebug("Debug message")
+        SDKLogger.logger.logFault("Fault message")
+        SDKLogger.logger.logError("Error message")
+
+        // Then
+        XCTAssertEqual(mockLogger.loggedMessages.count, 5, "All messages should be logged")
+        XCTAssertEqual(mockLogger.loggedMessages[0], "VERBOSE: Verbose message")
+        XCTAssertEqual(mockLogger.loggedMessages[1], "INFO: Info message")
+        XCTAssertEqual(mockLogger.loggedMessages[2], "DEBUG: Debug message")
+        XCTAssertEqual(mockLogger.loggedMessages[3], "FAULT: Fault message")
+        XCTAssertEqual(mockLogger.loggedMessages[4], "ERROR: Error message")
+    }
+
+    func testToggleLogging() {
+        // Given
+        SDKLogger.isLoggingEnabled = true
+
+        // When
+        SDKLogger.logger.logDebug("First message")
+        SDKLogger.isLoggingEnabled = false
+        SDKLogger.logger.logDebug("Second message")
+        SDKLogger.isLoggingEnabled = true
+        SDKLogger.logger.logDebug("Third message")
+
+        // Then
+        XCTAssertEqual(mockLogger.loggedMessages.count, 2, "Only messages when logging is enabled should be logged")
+        XCTAssertEqual(mockLogger.loggedMessages[0], "DEBUG: First message")
+        XCTAssertEqual(mockLogger.loggedMessages[1], "DEBUG: Third message")
+    }
+}

--- a/AmazonConnectChatIOSTests/Core/utils/TestUtils.swift
+++ b/AmazonConnectChatIOSTests/Core/utils/TestUtils.swift
@@ -8,9 +8,9 @@ struct TestUtils {
         let fileContents = "Sample text file contents"
         do {
             try fileContents.write(to: url, atomically: true, encoding: .utf8)
-            print("File created successfully at: \(url.path)")
+            SDKLogger.logger.logDebug("File created successfully at: \(url.path)")
         } catch {
-            print("Failed to create file: \(error.localizedDescription)")
+            SDKLogger.logger.logError("Failed to create file: \(error.localizedDescription)")
             return
         }
     }

--- a/README.md
+++ b/README.md
@@ -145,7 +145,17 @@ chatSession.configure(config: globalConfig)
 ```
 
 ### SDKLogger
-The `SDKLogger` class is responsible for logging relevant runtime information to the console which is useful for debugging purposes. The `SDKLogger` will log key events such as establishing a connection or failures such as failing to send a message.
+The `SDKLogger` class is responsible for logging relevant runtime information to the console which is useful for debugging purposes. The `SDKLogger` will log key events such as establishing a connection or failures such as failing to send a message. By default, logging is disabled and can be enabled/disabled at runtime.
+
+#### Enabling/Disabling Logging
+You can toggle logging on/off using the `isLoggingEnabled` flag:
+```swift
+// Enable logging
+SDKLogger.isLoggingEnabled = true
+
+// Disable logging
+SDKLogger.isLoggingEnabled = false
+```
 
 #### `SDKLogger.configure`
 This API will allow you to override the SDK's built-in logger with your own [SDKLoggerProtocol](#sdkloggerprotocol) implementation. This is especially useful in cases where you would want to store logs for debugging purposes. Attaching these logs to issues filed in this project will greatly expedite the resolution process.
@@ -154,7 +164,6 @@ This API will allow you to override the SDK's built-in logger with your own [SDK
 public static func configureLogger(_ logger: SDKLoggerProtocol) {
     SDKLogger.logger = logger
 }
-```
 
 #### SDKLoggerProtocol
 The SDKLoggerProtocol is a protocol used for the `SDKLogger`.  Users can override the `SDKLogger` with any class that implements SDKLoggerProtocol.

--- a/Sources/Core/Models/MessageContent.swift
+++ b/Sources/Core/Models/MessageContent.swift
@@ -69,7 +69,7 @@ public struct QuickReplyContent: InteractiveContent {
             let subtitle = quickReply.data.content.subtitle
             return QuickReplyContent(title: title, subtitle: subtitle, options: options)
         } catch {
-            print("Error decoding QuickReplyContent: \(error)")
+            SDKLogger.logger.logError("Error decoding QuickReplyContent: \(error)")
             return nil
         }
     }
@@ -119,7 +119,7 @@ public struct ListPickerContent: InteractiveContent {
             let imageUrl = listPicker.data.content.imageData
             return ListPickerContent(title: title, subtitle: subtitle, imageUrl: imageUrl, options: options)
         } catch {
-            print("Error decoding ListPickerContent: \(error)")
+            SDKLogger.logger.logError("Error decoding ListPickerContent: \(error)")
             return nil
         }
     }
@@ -175,7 +175,7 @@ public struct PanelContent: InteractiveContent {
             let options = panel.data.content.elements
             return PanelContent(title: title, subtitle: subtitle, imageUrl: imageUrl, imageDescription: imageDescription, options: options)
         } catch {
-            print("Error decoding PanelContent: \(error)")
+            SDKLogger.logger.logError("Error decoding PanelContent: \(error)")
             return nil
         }
     }
@@ -238,7 +238,7 @@ public struct TimePickerContent: InteractiveContent {
             let timeslots = timePicker.data.content.timeslots
             return TimePickerContent(title: title, subtitle: subtitle, timeZoneOffset: timeZoneOffset, location: location, timeslots: timeslots)
         } catch {
-            print("Error decoding TimePickerContent: \(error)")
+            SDKLogger.logger.logError("Error decoding TimePickerContent: \(error)")
             return nil
         }
     }
@@ -281,7 +281,7 @@ public struct CarouselContent: InteractiveContent {
             let elements = carousel.data.content.elements
             return CarouselContent(title: title, elements: elements)
         } catch {
-            print("Error decoding CarouselContent: \(error)")
+            SDKLogger.logger.logError("Error decoding CarouselContent: \(error)")
             return nil
         }
     }

--- a/Sources/Core/Network/MessageReceiptsManager.swift
+++ b/Sources/Core/Network/MessageReceiptsManager.swift
@@ -69,30 +69,30 @@ class MessageReceiptsManager: MessageReceiptsManagerProtocol {
         switch event {
         case .messageDelivered:
             if deliveredReceiptSet.contains(messageId) {
-                print("Delivered receipt already sent for messageId: \(messageId)")
+                SDKLogger.logger.logDebug("Delivered receipt already sent for messageId: \(messageId)")
                 return
             }
             if self.readReceiptSet.contains(messageId) {
-                print("Read receipt already sent for messageId: \(messageId)")
+                SDKLogger.logger.logDebug("Read receipt already sent for messageId: \(messageId)")
                 return
             }
             deliveredReceiptSet.insert(messageId)
             Timer.scheduledTimer(withTimeInterval: deliveredThrottleTime, repeats: false) { _ in
                 if self.readReceiptSet.contains(messageId) {
-                    print("Read receipt already sent for messageId: \(messageId)")
+                    SDKLogger.logger.logDebug("Read receipt already sent for messageId: \(messageId)")
                     return
                 } else {
-                    print("Sending Delivered receipt: \(messageId)")
+                    SDKLogger.logger.logDebug("Sending Delivered receipt: \(messageId)")
                     self.pendingMessageReceipts.deliveredReceiptMessageId = messageId
                 }
             }
             break
         case .messageRead:
             if readReceiptSet.contains(messageId) {
-                print("Read receipt already sent for messageId: \(messageId)")
+                SDKLogger.logger.logDebug("Read receipt already sent for messageId: \(messageId)")
                 return
             }
-            print("Sending read receipt: \(messageId)")
+            SDKLogger.logger.logDebug("Sending read receipt: \(messageId)")
             readReceiptSet.insert(messageId)
             pendingMessageReceipts.readReceiptMessageId = messageId
             break

--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -513,9 +513,9 @@ class ChatService : ChatServiceProtocol {
                 do {
                     // Delete the existing file
                     try FileManager.default.removeItem(at: tempFilePathUrl)
-                    print("Existing file deleted successfully.")
+                    SDKLogger.logger.logDebug("Existing file deleted successfully.")
                 } catch {
-                    print("Error deleting existing file: \(error)")
+                    SDKLogger.logger.logError("Error deleting existing file: \(error)")
                     completion(false, error)
                     return
                 }
@@ -631,10 +631,10 @@ class ChatService : ChatServiceProtocol {
             case .success(let url):
                 self.downloadFile(url: url, filename: filename) { (localUrl, error) in
                     if let localUrl = localUrl {
-                        print("File successfully downloaded to temporary directory")
+                        SDKLogger.logger.logDebug("File successfully downloaded to temporary directory")
                         completion(.success(localUrl))
                     } else if let error = error {
-                        print("Failed to download file: \(error.localizedDescription)")
+                        SDKLogger.logger.logError("Failed to download file: \(error.localizedDescription)")
                         completion(.failure(error))
                     }
                 }
@@ -667,9 +667,9 @@ class ChatService : ChatServiceProtocol {
                     do {
                         // Delete the existing file
                         try FileManager.default.removeItem(at: tempFilePathUrl)
-                        print("Existing file deleted successfully.")
+                        SDKLogger.logger.logDebug("Existing file deleted successfully.")
                     } catch {
-                        print("Error deleting existing file: \(error)")
+                        SDKLogger.logger.logError("Error deleting existing file: \(error)")
                         completion(nil, error)
                         return
                     }

--- a/Sources/Core/Service/ChatSession.swift
+++ b/Sources/Core/Service/ChatSession.swift
@@ -284,9 +284,9 @@ public class ChatSession: ChatSessionProtocol {
         sendReceipt(event: eventType, messageId: messageItem.id) { result in
             switch result {
             case .success:
-                print("Sent \(eventType.rawValue) receipt for \(messageItem.text)")
+                SDKLogger.logger.logDebug("Sent \(eventType.rawValue) receipt for \(messageItem.text)")
             case .failure(let error):
-                print("Error sending \(eventType.rawValue) receipt: \(error.localizedDescription)")
+                SDKLogger.logger.logError("Error sending \(eventType.rawValue) receipt: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/Core/Utils/HttpClient/DefaultHttpClient.swift
+++ b/Sources/Core/Utils/HttpClient/DefaultHttpClient.swift
@@ -150,7 +150,7 @@ class DefaultHttpClient: HttpClient {
                 onFailure(error)
                 return
             }
-            print(data.base64EncodedString())
+            SDKLogger.logger.logDebug(data.base64EncodedString())
             onSuccess(data)
         }.resume()
     }
@@ -188,10 +188,10 @@ class DefaultHttpClient: HttpClient {
         // Print the entire request for debugging
         if let requestData = try? JSONSerialization.data(withJSONObject: request.allHTTPHeaderFields ?? [:], options: .prettyPrinted),
            let requestBody = String(data: requestData, encoding: .utf8) {
-            print("Raw Request:")
-            print("URL: \(request.url?.absoluteString ?? "N/A")")
-            print("HTTP Method: \(request.httpMethod ?? "N/A")")
-            print("Headers:\n\(requestBody)")
+            SDKLogger.logger.logDebug("Raw Request:")
+            SDKLogger.logger.logDebug("URL: \(request.url?.absoluteString ?? "N/A")")
+            SDKLogger.logger.logDebug("HTTP Method: \(request.httpMethod ?? "N/A")")
+            SDKLogger.logger.logDebug("Headers:\n\(requestBody)")
         }
         
         let encoder = JSONEncoder()
@@ -222,10 +222,10 @@ class DefaultHttpClient: HttpClient {
         // Print the entire request for debugging
         if let requestData = try? JSONSerialization.data(withJSONObject: request.allHTTPHeaderFields ?? [:], options: .prettyPrinted),
            let requestBody = String(data: requestData, encoding: .utf8) {
-            print("Raw Request:")
-            print("URL: \(request.url?.absoluteString ?? "N/A")")
-            print("HTTP Method: \(request.httpMethod ?? "N/A")")
-            print("Headers:\n\(requestBody)")
+            SDKLogger.logger.logDebug("Raw Request:")
+            SDKLogger.logger.logDebug("URL: \(request.url?.absoluteString ?? "N/A")")
+            SDKLogger.logger.logDebug("HTTP Method: \(request.httpMethod ?? "N/A")")
+            SDKLogger.logger.logDebug("Headers:\n\(requestBody)")
         }
                 
         request.httpBody = body

--- a/Sources/Core/Utils/Logger/SDKLogger.swift
+++ b/Sources/Core/Utils/Logger/SDKLogger.swift
@@ -4,33 +4,40 @@
 import Foundation
 import OSLog
 
-
 public class SDKLogger: SDKLoggerProtocol {
     
     static var logger: SDKLoggerProtocol = SDKLogger()
     private let osLog: OSLog
     
+    /// Flag to enable/disable logging. Set to false by default.
+    public static var isLoggingEnabled: Bool = false
+
     private init() {
         osLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "SDK.DefaultSubsystem", category: "SDKLogging")
     }
     
     public func logVerbose(_ message: @autoclosure () -> String) {
+        guard SDKLogger.isLoggingEnabled else { return }
         os_log("%{public}@", log: osLog, type: .default, message())
     }
     
     public func logInfo(_ message: @autoclosure () -> String) {
+        guard SDKLogger.isLoggingEnabled else { return }
         os_log("%{public}@", log: osLog, type: .info, message())
     }
     
     public func logDebug(_ message: @autoclosure () -> String) {
+        guard SDKLogger.isLoggingEnabled else { return }
         os_log("%{public}@", log: osLog, type: .debug, message())
     }
     
     public func logFault(_ message: @autoclosure () -> String) {
+        guard SDKLogger.isLoggingEnabled else { return }
         os_log("%{public}@", log: osLog, type: .fault, message())
     }
     
     public func logError(_ message: @autoclosure () -> String) {
+        guard SDKLogger.isLoggingEnabled else { return }
         os_log("%{public}@", log: osLog, type: .error, message())
     }
     
@@ -38,9 +45,3 @@ public class SDKLogger: SDKLoggerProtocol {
         SDKLogger.logger = logger
     }
 }
-
-
-// How to use
-//SDKLogger.shared.logInfo("Application started successfully.")
-//SDKLogger.shared.logDebug("User data fetched from the database.")
-//SDKLogger.shared.logError("Failed to process user request.")


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

Description TODO - work in progress

 - Add isLoggingEnabled flag to control logging at runtime
 - Add unit tests for logger toggle functionality
 - Update README with toggle usage documentation
 - Default logging to disabled state for production safety
 
---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

