### PR TITLE
Revert 'Prepare for release 3.3.3' committed by mistake

### DIFF
--- a/AmazonConnectChatIOS.podspec
+++ b/AmazonConnectChatIOS.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
   spec.name          = 'AmazonConnectChatIOS'
-  spec.version       = '3.3.3'
+  spec.version       = '2.0.1'
   spec.license       = { :type => 'Apache License, Version 2.0', :file => "LICENSE" }
   spec.homepage      = 'https://github.com/amazon-connect/amazon-connect-chat-ios'
   spec.authors       = { 'Amazon Web Services' => 'amazonwebservices' }
   spec.summary       = 'Amazon Connect Chat SDK for iOS ...'
-  spec.source        = { :git => 'https://github.com/amazon-connect/amazon-connect-chat-ios', :tag => 'v3.3.3' }
+  spec.source        = { :git => 'https://github.com/amazon-connect/amazon-connect-chat-ios', :tag => 'v2.0.1' }
   spec.platform      = :ios, '15.0'
   spec.source_files  = "Sources/Core/**/*.{swift}"
   spec.dependency 'AWSConnectParticipant'


### PR DESCRIPTION
Revert 'Prepare for release 3.3.3' committed by mistake - https://github.com/amazon-connect/amazon-connect-chat-ios/commit/0ac028e091f3f5d97339d9ab3bf620a9cf00a754