### PR TITLE
Fixing and improving Build + Test CI Step

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -41,11 +41,34 @@ jobs:
     - name: Run Unit Tests
       run: |
         echo "::group::Run Unit Tests"
-        xcodebuild test -scheme AmazonConnectChatIOS \
-                        -sdk iphonesimulator \
-                        -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' \
-                        -configuration Debug \
-                        -enableCodeCoverage YES \
-                        -testPlan AmazonConnectChatIOS.xctestplan \
-                        2>&1 | xcpretty --color --simple
+        mkdir -p test_output
+        
+        # List available schemes to debug
+        echo "Available schemes:"
+        xcodebuild -list -project AmazonConnectChatIOS.xcodeproj
+        
+        # Use iPhone 15 with iOS 17.5
+        DESTINATION="platform=iOS Simulator,OS=17.5,name=iPhone 15"
+        
+        # Run tests with AmazonConnectChatIOSTests scheme
+        echo "Running tests with AmazonConnectChatIOSTests scheme..."
+        set -o pipefail && xcodebuild test -project AmazonConnectChatIOS.xcodeproj \
+                    -scheme AmazonConnectChatIOSTests \
+                    -sdk iphonesimulator \
+                    -destination "$DESTINATION" \
+                    -configuration Debug \
+                    -enableCodeCoverage YES \
+                    -resultBundlePath test_output/results.xcresult \
+                    | tee test_output/xcodebuild.log | xcpretty --color --test --report junit
+        
+        # Display failing tests more prominently
+        echo "::endgroup::"
+        
+        echo "::group::Failing Tests Summary"
+        if grep -q "Test Suite.*failed" test_output/xcodebuild*.log 2>/dev/null; then
+          echo "❌ FAILING TESTS DETECTED:"
+          grep -A 10 -B 2 "Test Case.*failed" test_output/xcodebuild*.log 2>/dev/null || true
+        else
+          echo "✅ All tests passed"
+        fi
         echo "::endgroup::"


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR fixes the `destination` that the tests run on.  Previously, it was set to iPhone 12 which was no longer supported as a testing device in GitHub Actions.  This uncovered a bug where the tests are not failing the CI step properly when a test fails.

This PR updates the `destination` to be an iPhone 15 build and improves logging of test failures and the logic within the step.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]  NO

*Does this change introduce any new dependency?* [YES/NO]. NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

NA

*List manual testing steps:*
 - Add Steps below: 
 
 NA

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

