### PR TITLE
Add delay after disconnect before cleaning up websocket 

### DIFF
--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -268,6 +268,7 @@ class ChatService : ChatServiceProtocol {
             case .success(_):
                 SDKLogger.logger.logDebug("Participant Disconnected")
                 self.eventPublisher.send(.chatEnded)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {}
                 self.websocketManager?.disconnect(reason: "Participant Disconnected")
                 self.clearSubscriptionsAndPublishers()
                 completion(true, nil)


### PR DESCRIPTION
**Issue Number:**

### Description:
Fixing issue where chat ended event is not published to transcript. See android for reference https://github.com/amazon-connect/amazon-connect-chat-android/blob/main/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt#L189

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES]

*Does this change introduce any new dependency?* [YES]

---

### Testing:
*Is the code unit tested?* yes

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?* yes

*List manual testing steps:*
 - Add Steps below: 

End chat and see the transcript updated 

TranscriptItem:
  id: f704d8bb-16b2-46fc-8c25-e27b9153e6e8
  persistentId: f704d8bb-16b2-46fc-8c25-e27b9153e6e8
  timeStamp: 2025-07-15T19:23:09.811Z
  contentType: application/vnd.amazonaws.connect.event.chat.ended
  serializedContent: ["contentType": application/json, "content": {"AbsoluteTime":"2025-07-15T19:23:09.811Z","ContentType":"application/vnd.amazonaws.connect.event.chat.ended","Id":"f704d8bb-16b2-46fc-8c25-e27b9153e6e8","Type":"EVENT


Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

