### PR TITLE
fix chatsession.onChatEnded not firing

### DIFF
--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -268,10 +268,11 @@ class ChatService : ChatServiceProtocol {
             case .success(_):
                 SDKLogger.logger.logDebug("Participant Disconnected")
                 self.eventPublisher.send(.chatEnded)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {}
-                self.websocketManager?.disconnect(reason: "Participant Disconnected")
-                self.clearSubscriptionsAndPublishers()
-                completion(true, nil)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.websocketManager?.disconnect(reason: "Participant Disconnected")
+                    self.clearSubscriptionsAndPublishers()
+                    completion(true, nil)
+                }
             case .failure(let error):
                 completion(false, error)
             }

--- a/Sources/Core/Utils/CommonUtils.swift
+++ b/Sources/Core/Utils/CommonUtils.swift
@@ -57,6 +57,6 @@ struct CommonUtils {
     }
     
     static func getLibraryVersion() -> String {
-        return "2.0.4"
+        return "2.0.5"
     }
 }


### PR DESCRIPTION
**Issue Number:**

### Description:
Chatsession.onEnded event was not firing previously. This adds delay so that the event is processed

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES]

*Does this change introduce any new dependency?* [YES]

---

### Testing:
*Is the code unit tested?* yes

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?* yes



*List manual testing steps:*
 
End chat and see the event in onMessage, onTranscript and chatSession.onEnded

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

