### PR TITLE
Fix message timestamp display and ordering issues

### DIFF
--- a/Sources/Core/Utils/TranscriptItemUtils.swift
+++ b/Sources/Core/Utils/TranscriptItemUtils.swift
@@ -18,9 +18,6 @@ struct TranscriptItemUtils {
     }
     
     static func createDummyMessage(content: String, contentType: String, status: MessageStatus, attachmentId: String? = nil, displayName: String) -> Message {
-        // Use empty string for sending messages so no timestamp is displayed
-        // Sorting is handled by checking .Sending status in transcript logic
-        let isoTime = ""
         let randomId = UUID().uuidString
         
         return Message(
@@ -28,12 +25,12 @@ struct TranscriptItemUtils {
             text: content,
             contentType: contentType,
             messageDirection: .Outgoing,
-            timeStamp: isoTime,
+            timeStamp: "", // Empty string for sending messages - no timestamp displayed, sorting handled by transcript logic
             attachmentId: attachmentId,
             messageId: randomId,
             displayName: displayName,
             serializedContent: [:],
-            metadata: Metadata(status: status, timeStamp: isoTime, contentType: contentType, eventDirection: .Outgoing, serializedContent: [:]),
+            metadata: Metadata(status: status, timeStamp: "", contentType: contentType, eventDirection: .Outgoing, serializedContent: [:]), // Empty timestamp for metadata too
             persistentId: randomId
         )
     }

--- a/Sources/Core/Utils/TranscriptItemUtils.swift
+++ b/Sources/Core/Utils/TranscriptItemUtils.swift
@@ -18,7 +18,9 @@ struct TranscriptItemUtils {
     }
     
     static func createDummyMessage(content: String, contentType: String, status: MessageStatus, attachmentId: String? = nil, displayName: String) -> Message {
-        let isoTime = CommonUtils.getCurrentISOTime()
+        // Use empty string for sending messages so no timestamp is displayed
+        // Sorting is handled by checking .Sending status in transcript logic
+        let isoTime = ""
         let randomId = UUID().uuidString
         
         return Message(


### PR DESCRIPTION
### Description:
*What are the changes? Why are we making them?*

- Use empty string timestamps for sending messages 
- Add special transcript insertion logic to ensure sending messages appear at end
- Update failed messages with current timestamp when failure occurs
- Add WebSocket message handling to replace placeholder timestamps with server timestamps
- Ensure proper chronological ordering while maintaining immediate UI feedback

Fixes issues where:
1. Message ordering could be disrupted during slow networks and different device times



---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [No]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?* Yes

https://github.com/user-attachments/assets/1b154855-5f60-471f-88ae-7baea37d074d


https://github.com/user-attachments/assets/94f938f0-410a-406b-a091-b103546a09bf


*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?* Yes
 
*List manual testing steps:*
 - Add Steps below: 

Send and receive message. Update device time to be in the past and send and receive message. Test same scenarios for failed to send messages and retry
