### PR TITLE
Use device time for sending messages instead of empty timestamps

### DIFF
--- a/Sources/Core/Utils/TranscriptItemUtils.swift
+++ b/Sources/Core/Utils/TranscriptItemUtils.swift
@@ -18,6 +18,7 @@ struct TranscriptItemUtils {
     }
     
     static func createDummyMessage(content: String, contentType: String, status: MessageStatus, attachmentId: String? = nil, displayName: String) -> Message {
+        let deviceTime = CommonUtils.getCurrentISOTime()
         let randomId = UUID().uuidString
         
         return Message(
@@ -25,12 +26,12 @@ struct TranscriptItemUtils {
             text: content,
             contentType: contentType,
             messageDirection: .Outgoing,
-            timeStamp: "", // Empty string for sending messages - no timestamp displayed, sorting handled by transcript logic
+            timeStamp: deviceTime,
             attachmentId: attachmentId,
             messageId: randomId,
             displayName: displayName,
             serializedContent: [:],
-            metadata: Metadata(status: status, timeStamp: "", contentType: contentType, eventDirection: .Outgoing, serializedContent: [:]), // Empty timestamp for metadata too
+            metadata: Metadata(status: status, timeStamp: deviceTime, contentType: contentType, eventDirection: .Outgoing, serializedContent: [:]),
             persistentId: randomId
         )
     }


### PR DESCRIPTION


There is a public interface which says timestamp cannot be empty. Using device time for sending state

**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

