### PR TITLE
Add public initializers for TranscriptData and ConnectionDetails

### DIFF
--- a/Sources/Core/Models/ConnectionDetails.swift
+++ b/Sources/Core/Models/ConnectionDetails.swift
@@ -8,6 +8,12 @@ public struct ConnectionDetails {
     let connectionToken: String?
     let expiry: Date?
     
+    public init(websocketUrl: String?, connectionToken: String?, expiry: Date?) {
+        self.websocketUrl = websocketUrl
+        self.connectionToken = connectionToken
+        self.expiry = expiry
+    }
+    
     public func getWebsocketUrl() -> String? {
         return websocketUrl
     }

--- a/Sources/Core/Models/TranscriptItem.swift
+++ b/Sources/Core/Models/TranscriptItem.swift
@@ -54,4 +54,9 @@ public class TranscriptItem: TranscriptItemProtocol {
 public struct TranscriptData {
     public let transcriptList: [TranscriptItem]
     public let previousTranscriptNextToken: String?
+    
+    public init(transcriptList: [TranscriptItem], previousTranscriptNextToken: String?) {
+        self.transcriptList = transcriptList
+        self.previousTranscriptNextToken = previousTranscriptNextToken
+    }
 }


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

We are making `TranscriptData` and `ConnectionDetails` initializers public to help consuming projects test more effectively.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

NA

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

