### PR TITLE
chore: update library version to 2.0.6

### DIFF
--- a/Sources/Core/Utils/CommonUtils.swift
+++ b/Sources/Core/Utils/CommonUtils.swift
@@ -57,6 +57,6 @@ struct CommonUtils {
     }
     
     static func getLibraryVersion() -> String {
-        return "2.0.5"
+        return "2.0.6"
     }
 }


### PR DESCRIPTION
📦 Version Update:
- Updated getLibraryVersion() from 2.0.5 to 2.0.6
- Reflects latest SDK improvements and event callback features

🔧 Changes:
- CommonUtils.getLibraryVersion(): '2.0.5' → '2.0.6'

✅ This version includes:
- Comprehensive event callback system (10 new callbacks)
- Attachment status progression fixes
- Enhanced participant event handling
- Improved receipt callback functionality
- Connection state management improvements

Prepares SDK for 2.0.6 release with new event handling capabilities.

**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

