### PR TITLE
Demonstrate CI build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 * [License](#license)
 
 ## About
+
+**Note: CI build is currently failing with missing AWSConnectParticipant-Target.o error. This PR demonstrates the issue without any code changes.**
+
 The Amazon Connect Chat SDK for iOS is a Swift library that gives you the power to easily integrate Amazon Connect Chat directly into your native iOS applications. The Amazon Connect Chat SDK helps handle client side chat logic and back-end communications similar to the [Amazon Connect ChatJS Library](https://github.com/amazon-connect/amazon-connect-chatjs). The SDK wraps the [Amazon Connect Participant Service](https://docs.aws.amazon.com/connect/latest/APIReference/API_Operations_Amazon_Connect_Participant_Service.html) APIs and abstracts away the management of the chat session and WebSocket.  This allows you to focus on the user interface and experience while relying on the Amazon Connect Chat SDK to interact with all the back-end services.  This approach still requires using your own chat back end to call the Amazon Connect [StartChatContact](https://docs.aws.amazon.com/connect/latest/APIReference/API_StartChatContact.html) API to initiate contact. You can read instructions on how to quickly set up a StartChatContact Lambda from our [startChatContactAPI](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/cloudformationTemplates/startChatContactAPI) example.
 
 ## Installation Steps


### PR DESCRIPTION
Add note to README showing that CI is currently failing with AWSConnectParticipant-Target.o error without any code changes.

**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session
* Quick Connect transfer failed should show the transfer failed event in the transcript

