### PR TITLE
Fix S3 attachment upload with SSE-KMS encryption

### DIFF
--- a/Sources/Core/Utils/HttpClient/HttpHeader.swift
+++ b/Sources/Core/Utils/HttpClient/HttpHeader.swift
@@ -21,6 +21,9 @@ extension HttpHeader {
         case contentDisposition = "Content-Disposition"
         case amzMetaAccountId = "x-amz-meta-account_id"
         case amzExpctedBucketOwner = "x-amz-expected-bucket-owner"
+        case amzServerSideEncryption = "x-amz-server-side-encryption"
+        case amzServerSideEncryptionAwsKmsKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case amzServerSideEncryptionContext = "x-amz-server-side-encryption-context"
     }
 }
 


### PR DESCRIPTION
**Issue Number:**
#95 

### Description:
*What are the changes? Why are we making them?*

S3 attachment uploads fail with 403 SignatureDoesNotMatch error when Amazon Connect instance uses Server-Side Encryption with KMS keys. The iOS SDK was missing required SSE-KMS headers in the HttpHeader.Key enum, causing them to be filtered out during upload.

Added missing SSE-KMS headers to HttpHeader.Key enum:
- `x-amz-server-side-encryption`
- `x-amz-server-side-encryption-aws-kms-key-id` 
- `x-amz-server-side-encryption-context`
---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?*  [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*
NA

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session
* Quick Connect transfer failed should show the transfer failed event in the transcript

