### PR TITLE
Adding support for SUPERVISOR and CUSTOM_BOT participant types

### DIFF
--- a/Sources/Core/Utils/CommonUtils.swift
+++ b/Sources/Core/Utils/CommonUtils.swift
@@ -14,6 +14,10 @@ struct CommonUtils {
             return Constants.CUSTOMER
         case AWSConnectParticipantParticipantRole.system.rawValue:
             return Constants.SYSTEM
+        case AWSConnectParticipantParticipantRole.supervisor.rawValue:
+            return Constants.SUPERVISOR
+        case AWSConnectParticipantParticipantRole.customBot.rawValue:
+            return Constants.CUSTOM_BOT
         default:
             return Constants.UNKNOWN
         }

--- a/Sources/Core/Utils/Constants.swift
+++ b/Sources/Core/Utils/Constants.swift
@@ -10,6 +10,8 @@ public struct Constants {
     static let AGENT = "AGENT"
     static let CUSTOMER = "CUSTOMER"
     static let SYSTEM = "SYSTEM"
+    static let SUPERVISOR = "SUPERVISOR"
+    static let CUSTOM_BOT = "CUSTOM_BOT"
     static let UNKNOWN = "UNKNOWN"
     static let MESSAGE = "MESSAGE"
     static let ATTACHMENT = "ATTACHMENT"


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR adds support for `SUPERVISOR` and `CUSTOM_BOT` participant types. 

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session
* Quick Connect transfer failed should show the transfer failed event in the transcript

