### PR TITLE
Setting isChatActive state to false on dummy end

### DIFF
--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -866,6 +866,7 @@ class ChatService : ChatServiceProtocol {
                         if nsError.localizedFailureReason == "AccessDeniedException" {
                             self?.updateTranscriptDict(with: TranscriptItemUtils.createDummyEndedEvent())
                             self?.eventPublisher.send(.chatEnded)
+                            ConnectionDetailsProvider.shared.setChatSessionState(isActive: false)
                         }
                         SDKLogger.logger.logError("CreateParticipantConnection failed \(nsError)")
 


### PR DESCRIPTION
**Issue Number:**

### Description:

We enter the "dummy end" scenario where the chat is ended by the back-end while the client's WebSocket is disconnected.  WebSocket is disconnected on network disruptions, app backgrounds, locked phone, etc.

When the client returns and attempts to re-connect to its previous chat session, it will receive a 403 forbidden because the chat has already ended on the back-end.  When we receive this 403 error, we assume the chat has ended and execute the "dummy end" scenario.

This PR makes a fix that sets the `isChatActive` boolean to `false` when this happens.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

NO

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session
* Quick Connect transfer failed should show the transfer failed event in the transcript

