### PR TITLE
Improving onTranscriptUpdated logic for GetTranscript calls

### DIFF
--- a/Sources/Core/Service/ChatService.swift
+++ b/Sources/Core/Service/ChatService.swift
@@ -819,13 +819,6 @@ class ChatService : ChatServiceProtocol {
                 
                 if let websocketManager = self?.websocketManager {
                     let formattedItems = websocketManager.formatAndProcessTranscriptItems(transcriptItems)
-                    
-                    // Dispatch the transcript list update to the next run loop cycle
-                    // to ensure formatAndProcessTranscriptItems completes all its internal processing
-                    DispatchQueue.main.async {
-                        self?.triggerTranscriptListUpdate()
-                    }
-                    
                     let transcriptResponse = TranscriptResponse(
                         initialContactId: response.initialContactId ?? "",
                         nextToken: response.nextToken ?? "", // Handle nextToken if it is available in the response


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

The timing of `triggerTranscriptListUpdate` is still not reliably firing AFTER all the transcript items from `GetTranscript` are processed and placed into the internal transcript.

Modifying the logic so that we just track the last item in the `getTranscript` to determine when to send the transcript updated event.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [iOS Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/iOSChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session
* Quick Connect transfer failed should show the transfer failed event in the transcript

