### PR TITLE
Declare SDK telemetry in PrivacyInfo manifest

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -20,6 +20,19 @@
             <key>linked</key>
             <false/>
         </dict>
+        <dict>
+            <key>type</key>
+            <string>product_interaction</string>
+            <key>purpose</key>
+            <array>
+                <string>analytics</string>
+                <string>app_functionality</string>
+            </array>
+            <key>optional</key>
+            <true/>
+            <key>linked</key>
+            <false/>
+        </dict>
     </array>
     <key>NSPrivacyAccessedAPITypes</key>
     <array/>


### PR DESCRIPTION
### Description:
The SDK emits two operational count metrics by default (CreateParticipantConnection and SendMessage success counters) to an AWS telemetry endpoint. Updating the privacy manifest to reflect this.

Add a product_interaction entry covering the metrics, marked unlinked and non-tracking, with analytics and app_functionality purposes. Telemetry can be disabled via GlobalConfig(disableCsm: true).

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* NO

*Does this change introduce any new dependency?* NO

---

### Testing:
N/A - non functional change.

